### PR TITLE
change writing wav files to use libsndfile

### DIFF
--- a/initialize_dataset.py
+++ b/initialize_dataset.py
@@ -7,6 +7,7 @@ import librosa
 from shutil import copyfile
 import numpy as np
 from pathlib import Path   
+import soundfile as sf
     
     
 def clip_and_copy_audio(in_path, out_path, start=None, end=None, padding=0.5):
@@ -60,7 +61,7 @@ def clip_and_copy_audio(in_path, out_path, start=None, end=None, padding=0.5):
             zeros = np.zeros((data.shape[0], samples))
             data = np.asfortranarray(np.concatenate( (zeros,data),axis=1))
     
-    librosa.output.write_wav(out_path, y=data.astype(np.float32), sr=sr, norm=False)
+    sf.write(file=out_path, data=data.astype(np.float32).T, samplerate=sr, subtype='PCM_24')
 
 
 

--- a/initialize_dataset.py
+++ b/initialize_dataset.py
@@ -61,7 +61,7 @@ def clip_and_copy_audio(in_path, out_path, start=None, end=None, padding=0.5):
             zeros = np.zeros((data.shape[0], samples))
             data = np.asfortranarray(np.concatenate( (zeros,data),axis=1))
     
-    sf.write(file=out_path, data=data.astype(np.float32).T, samplerate=sr, subtype='PCM_24')
+    sf.write(file=out_path, data=data.astype(np.float32).T, samplerate=sr, subtype='FLOAT')
 
 
 


### PR DESCRIPTION
since 0.7 librosa has deprecated it's own audio read/write function and uses soundfile instead:
https://librosa.org/doc/latest/ioformats.html

When running the `initialize_dataset.py` script with a newer librosa version (e.g. 1.0) the files which have to be cut cannot be written sind `librosa.output` no longer exists.
