### PR TITLE
Fix incorrect divisions in Beethoven/Piano_Sonatas/17-2, missing dots and incorrect voices

### DIFF
--- a/Beethoven/Piano_Sonatas/17-2/xml_score.musicxml
+++ b/Beethoven/Piano_Sonatas/17-2/xml_score.musicxml
@@ -28037,14 +28037,25 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>3360</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
+        <dot/>
         <stem>down</stem>
         <staff>1</staff>
         <notations>
           <slur type="stop" number="1"/>
           </notations>
+        </note>
+      <backup>
+        <duration>5040</duration>
+        </backup>
+      <note print-object="no">
+        <rest/>
+        <duration>3360</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <staff>1</staff>
         </note>
       <note default-x="148.24" default-y="-30.00">
         <cue/>
@@ -28053,7 +28064,7 @@
           <octave>4</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
         <time-modification>
@@ -28077,7 +28088,7 @@
           <octave>4</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28096,7 +28107,7 @@
           <octave>4</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
         <time-modification>
@@ -28116,7 +28127,7 @@
           <octave>4</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28135,7 +28146,7 @@
           <octave>4</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28154,7 +28165,7 @@
           <octave>4</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28174,7 +28185,7 @@
           <octave>4</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28193,7 +28204,7 @@
           <octave>5</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28212,7 +28223,7 @@
           <octave>5</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28232,7 +28243,7 @@
           <octave>5</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
         <time-modification>
@@ -28252,7 +28263,7 @@
           <octave>5</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28271,7 +28282,7 @@
           <octave>5</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28290,7 +28301,7 @@
           <octave>5</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28310,7 +28321,7 @@
           <octave>5</octave>
           </pitch>
         <duration>120</duration>
-        <voice>1</voice>
+        <voice>2</voice>
         <type>32nd</type>
         <time-modification>
           <actual-notes>14</actual-notes>
@@ -28327,7 +28338,7 @@
           </notations>
         </note>
       <backup>
-        <duration>5145</duration>
+        <duration>5080</duration>
         </backup>
       <note default-x="106.14" default-y="-138.10">
         <pitch>

--- a/Beethoven/Piano_Sonatas/17-2/xml_score.musicxml
+++ b/Beethoven/Piano_Sonatas/17-2/xml_score.musicxml
@@ -637,7 +637,7 @@
         <beam number="2">begin</beam>
         <beam number="3">begin</beam>
         <notations>
-          <tuplet type="start"/>
+          <tuplet type="start" bracket="no" show-number="none"/>
           <slur type="start" placement="below" number="1"/>
           </notations>
         </note>

--- a/Beethoven/Piano_Sonatas/17-2/xml_score.musicxml
+++ b/Beethoven/Piano_Sonatas/17-2/xml_score.musicxml
@@ -80,7 +80,7 @@
           </staff-layout>
         </print>
       <attributes>
-        <divisions>480</divisions>
+        <divisions>1680</divisions>
         <key>
           <fifths>-2</fifths>
           </key>
@@ -110,7 +110,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -123,7 +123,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -137,7 +137,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -145,7 +145,7 @@
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <direction placement="above">
         <direction-type>
@@ -162,7 +162,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -178,7 +178,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -195,7 +195,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -211,7 +211,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -227,7 +227,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -244,7 +244,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -261,7 +261,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -279,7 +279,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -296,7 +296,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -307,7 +307,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -319,7 +319,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -332,25 +332,25 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -361,7 +361,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -373,7 +373,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -386,7 +386,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -400,7 +400,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -413,7 +413,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -426,7 +426,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -434,14 +434,14 @@
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-181.65">
         <pitch>
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -454,7 +454,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -467,7 +467,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -481,7 +481,7 @@
           <step>A</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -496,7 +496,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -510,7 +510,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -521,7 +521,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -534,25 +534,25 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -562,7 +562,7 @@
           <step>A</step>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -574,7 +574,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -588,9 +588,10 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
+        <dot/>
         <stem>up</stem>
         <staff>1</staff>
         </note>
@@ -600,10 +601,21 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
+        <dot/>
         <stem>up</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>5040</duration>
+        </backup>
+      <note print-object="no">
+        <rest/>
+        <duration>3360</duration>
+        <voice>2</voice>
+        <type>half</type>
         <staff>1</staff>
         </note>
       <note default-x="69.69" default-y="-45.00">
@@ -612,15 +624,20 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
-        <voice>1</voice>
+        <duration>168</duration>
+        <voice>2</voice>
         <type>32nd</type>
+        <time-modification>
+          <actual-notes>10</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">begin</beam>
         <beam number="2">begin</beam>
         <beam number="3">begin</beam>
         <notations>
+          <tuplet type="start"/>
           <slur type="start" placement="below" number="1"/>
           </notations>
         </note>
@@ -630,9 +647,13 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
-        <voice>1</voice>
+        <duration>168</duration>
+        <voice>2</voice>
         <type>32nd</type>
+        <time-modification>
+          <actual-notes>10</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">continue</beam>
@@ -646,9 +667,13 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
-        <voice>1</voice>
+        <duration>168</duration>
+        <voice>2</voice>
         <type>32nd</type>
+        <time-modification>
+          <actual-notes>10</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">continue</beam>
@@ -661,9 +686,13 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
-        <voice>1</voice>
+        <duration>168</duration>
+        <voice>2</voice>
         <type>32nd</type>
+        <time-modification>
+          <actual-notes>10</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">continue</beam>
@@ -677,9 +706,13 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
-        <voice>1</voice>
+        <duration>168</duration>
+        <voice>2</voice>
         <type>32nd</type>
+        <time-modification>
+          <actual-notes>10</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">continue</beam>
@@ -692,9 +725,13 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
-        <voice>1</voice>
+        <duration>168</duration>
+        <voice>2</voice>
         <type>32nd</type>
+        <time-modification>
+          <actual-notes>10</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">continue</beam>
@@ -707,9 +744,13 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
-        <voice>1</voice>
+        <duration>168</duration>
+        <voice>2</voice>
         <type>32nd</type>
+        <time-modification>
+          <actual-notes>10</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">continue</beam>
@@ -722,9 +763,13 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
-        <voice>1</voice>
+        <duration>168</duration>
+        <voice>2</voice>
         <type>32nd</type>
+        <time-modification>
+          <actual-notes>10</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">continue</beam>
@@ -738,9 +783,13 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
-        <voice>1</voice>
+        <duration>168</duration>
+        <voice>2</voice>
         <type>32nd</type>
+        <time-modification>
+          <actual-notes>10</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">continue</beam>
@@ -753,27 +802,25 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
-        <voice>1</voice>
+        <duration>168</duration>
+        <voice>2</voice>
         <type>32nd</type>
+        <time-modification>
+          <actual-notes>10</actual-notes>
+          <normal-notes>8</normal-notes>
+          </time-modification>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">end</beam>
         <beam number="2">end</beam>
         <beam number="3">end</beam>
         <notations>
+          <tuplet type="stop"/>
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note print-object="no">
-        <rest/>
-        <duration>60</duration>
-        <voice>1</voice>
-        <type>32nd</type>
-        <staff>1</staff>
-        </note>
       <backup>
-        <duration>1620</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-151.65">
         <pitch>
@@ -781,9 +828,10 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
+        <dot/>
         <stem>down</stem>
         <staff>2</staff>
         </note>
@@ -793,29 +841,11 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
+        <dot/>
         <stem>down</stem>
-        <staff>2</staff>
-        </note>
-      <note print-object="no">
-        <rest/>
-        <duration>480</duration>
-        <voice>5</voice>
-        <type>quarter</type>
-        <staff>2</staff>
-        </note>
-      <backup>
-        <duration>240</duration>
-        </backup>
-      <note print-object="no">
-        <rest/>
-        <duration>420</duration>
-        <voice>5</voice>
-        <type>eighth</type>
-        <dot/>
-        <dot/>
         <staff>2</staff>
         </note>
       </measure>
@@ -825,7 +855,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -843,7 +873,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -860,7 +890,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -879,14 +909,14 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>480</duration>
+        <duration>1680</duration>
         </backup>
       <note default-x="92.10" default-y="-25.00">
         <pitch>
@@ -894,7 +924,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -902,18 +932,18 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -923,7 +953,7 @@
           <step>B</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <accidental>natural</accidental>
@@ -931,14 +961,14 @@
         <staff>2</staff>
         </note>
       <backup>
-        <duration>480</duration>
+        <duration>1680</duration>
         </backup>
       <note default-x="92.10" default-y="-141.65">
         <pitch>
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -968,7 +998,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -983,7 +1013,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -998,7 +1028,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -1010,7 +1040,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -1028,7 +1058,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -1042,14 +1072,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="14.36" default-y="-30.00" dynamics="61.11">
         <pitch>
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>2</voice>
         <type>quarter</type>
         <dot/>
@@ -1062,7 +1092,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -1076,7 +1106,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -1089,7 +1119,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -1097,14 +1127,14 @@
         <beam number="1">end</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="14.36" default-y="-116.65" dynamics="61.11">
         <pitch>
           <step>B</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <accidental>natural</accidental>
@@ -1119,7 +1149,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -1134,7 +1164,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -1147,7 +1177,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -1159,7 +1189,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -1168,7 +1198,7 @@
         <beam number="1">end</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="14.36" default-y="-136.65" dynamics="61.11">
         <pitch>
@@ -1176,7 +1206,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>6</voice>
         <type>quarter</type>
         <dot/>
@@ -1188,7 +1218,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>6</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -1200,7 +1230,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>6</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -1218,7 +1248,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>6</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -1250,7 +1280,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -1294,7 +1324,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -1307,7 +1337,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -1323,7 +1353,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -1331,20 +1361,20 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note print-object="no">
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="113.85" default-y="-20.00" dynamics="77.78">
         <pitch>
@@ -1352,7 +1382,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -1366,7 +1396,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -1376,7 +1406,7 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note default-x="101.99" default-y="-10.00" print-object="no" dynamics="77.78">
         <cue/>
@@ -1384,7 +1414,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -1400,7 +1430,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -1416,7 +1446,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -1432,7 +1462,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -1448,7 +1478,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -1464,7 +1494,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -1480,7 +1510,7 @@
           <step>B</step>
           <octave>4</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <accidental>natural</accidental>
@@ -1497,7 +1527,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -1508,14 +1538,14 @@
         <beam number="4">end</beam>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="101.99" default-y="-92.52" dynamics="77.78">
         <pitch>
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <accidental>natural</accidental>
@@ -1530,7 +1560,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -1544,27 +1574,27 @@
           <display-step>F</display-step>
           <display-octave>3</display-octave>
           </rest>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note print-object="no">
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="101.99" default-y="-122.52" dynamics="77.78">
         <pitch>
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>6</voice>
         <type>quarter</type>
         <dot/>
@@ -1573,14 +1603,14 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>6</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>6</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -1590,7 +1620,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>6</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -1607,7 +1637,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>6</voice>
         <type>16th</type>
         <accidental>flat</accidental>
@@ -1622,7 +1652,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>6</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -1633,7 +1663,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>6</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -1650,7 +1680,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>6</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -1664,7 +1694,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -1672,7 +1702,7 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="14.16" default-y="-142.52" dynamics="84.44">
         <pitch>
@@ -1680,7 +1710,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -1698,7 +1728,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -1711,7 +1741,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -1727,7 +1757,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -1738,7 +1768,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -1753,7 +1783,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -1764,7 +1794,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -1776,14 +1806,14 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-177.52" dynamics="84.44">
         <pitch>
@@ -1791,7 +1821,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>6</voice>
         <type>half</type>
         <dot/>
@@ -1805,7 +1835,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -1820,7 +1850,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -1840,7 +1870,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -1857,7 +1887,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -1868,7 +1898,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -1880,7 +1910,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -1893,14 +1923,14 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="42.14" default-y="-5.00" print-object="no" dynamics="78.89">
         <cue/>
@@ -1909,7 +1939,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -1932,7 +1962,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -1952,7 +1982,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -1970,7 +2000,7 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="10.36" default-y="-142.52" dynamics="78.89">
         <pitch>
@@ -1978,7 +2008,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>down</stem>
@@ -1990,7 +2020,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>down</stem>
@@ -2002,7 +2032,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>down</stem>
@@ -2014,7 +2044,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2027,7 +2057,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2040,7 +2070,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -2048,14 +2078,14 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="14.16" default-y="-137.52" dynamics="84.44">
         <pitch>
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -2074,7 +2104,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -2087,7 +2117,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -2102,7 +2132,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -2114,7 +2144,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2130,7 +2160,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -2143,7 +2173,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2156,21 +2186,21 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-192.52" dynamics="84.44">
         <pitch>
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>6</voice>
         <type>half</type>
         <dot/>
@@ -2183,7 +2213,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>6</voice>
         <type>half</type>
         <dot/>
@@ -2209,7 +2239,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -2224,7 +2254,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -2243,7 +2273,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -2261,7 +2291,7 @@
           <alter>-1</alter>
           <octave>6</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2281,7 +2311,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -2294,7 +2324,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -2302,7 +2332,7 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="135.00" default-y="25.00" print-object="no" dynamics="90.00">
         <cue/>
@@ -2310,7 +2340,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -2333,7 +2363,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -2353,7 +2383,7 @@
           <step>B</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <accidental>natural</accidental>
@@ -2372,14 +2402,14 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="101.78" default-y="-190.00" dynamics="90.00">
         <pitch>
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2392,7 +2422,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2405,7 +2435,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -2414,7 +2444,7 @@
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -2425,7 +2455,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2437,7 +2467,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2450,7 +2480,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -2458,7 +2488,7 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="35.06" default-y="-40.00" dynamics="95.56">
         <pitch>
@@ -2466,7 +2496,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -2474,34 +2504,34 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-145.00" dynamics="95.56">
         <pitch>
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -2519,7 +2549,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -2532,7 +2562,7 @@
           <step>B</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -2548,7 +2578,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -2559,7 +2589,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2575,7 +2605,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2586,7 +2616,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2599,7 +2629,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2612,7 +2642,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -2627,7 +2657,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -2646,7 +2676,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -2664,7 +2694,7 @@
           <alter>-1</alter>
           <octave>6</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2675,7 +2705,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2692,14 +2722,14 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="47.93" default-y="25.00" print-object="no" dynamics="101.11">
         <cue/>
@@ -2707,7 +2737,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -2730,7 +2760,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -2750,7 +2780,7 @@
           <step>B</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <accidental>natural</accidental>
@@ -2769,7 +2799,7 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="13.80" default-y="-125.00" dynamics="101.11">
         <pitch>
@@ -2777,7 +2807,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>up</stem>
@@ -2789,7 +2819,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2799,14 +2829,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-135.00" dynamics="101.11">
         <pitch>
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2820,7 +2850,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -2834,21 +2864,21 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-155.00" dynamics="101.11">
         <pitch>
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>7</voice>
         <type>half</type>
         <stem>down</stem>
@@ -2860,7 +2890,7 @@
           <alter>1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>7</voice>
         <type>quarter</type>
         <accidental>sharp</accidental>
@@ -2875,7 +2905,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -2891,7 +2921,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -2899,7 +2929,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -2918,18 +2948,18 @@
           <step>G</step>
           <octave>5</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>960</duration>
+        <duration>3360</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -2939,7 +2969,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -2958,7 +2988,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -2971,7 +3001,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -2980,20 +3010,20 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-150.00" dynamics="101.11">
         <pitch>
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -3009,7 +3039,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -3021,7 +3051,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -3029,7 +3059,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -3045,7 +3075,7 @@
         </direction>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -3055,7 +3085,7 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -3075,7 +3105,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -3088,7 +3118,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -3097,7 +3127,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -3118,7 +3148,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
@@ -3126,20 +3156,20 @@
         </note>
       <note print-object="no">
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>D</display-step>
           <display-octave>5</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -3149,7 +3179,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -3168,7 +3198,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -3180,7 +3210,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -3189,7 +3219,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -3199,7 +3229,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3218,7 +3248,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3230,7 +3260,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3238,17 +3268,17 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -3267,7 +3297,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -3286,7 +3316,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -3298,7 +3328,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -3307,7 +3337,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -3317,7 +3347,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3335,7 +3365,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3343,7 +3373,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -3368,7 +3398,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3386,7 +3416,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3399,7 +3429,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3407,27 +3437,27 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="94.27" default-y="-170.00">
         <pitch>
@@ -3435,7 +3465,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3454,7 +3484,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3462,7 +3492,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -3473,7 +3503,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -3496,7 +3526,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -3515,7 +3545,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -3538,7 +3568,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3552,7 +3582,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -3563,7 +3593,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -3586,7 +3616,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -3605,7 +3635,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -3628,7 +3658,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3642,7 +3672,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -3653,7 +3683,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -3676,7 +3706,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -3695,7 +3725,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -3719,7 +3749,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -3735,7 +3765,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -3748,7 +3778,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -3759,7 +3789,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -3772,7 +3802,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -3784,7 +3814,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -3795,7 +3825,7 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>natural</accidental>
@@ -3812,7 +3842,7 @@
           <alter>1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>sharp</accidental>
@@ -3825,14 +3855,14 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-170.00">
         <pitch>
@@ -3840,7 +3870,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3854,21 +3884,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -3880,7 +3910,7 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>natural</accidental>
@@ -3897,7 +3927,7 @@
           <alter>1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>sharp</accidental>
@@ -3910,7 +3940,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -3921,7 +3951,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3937,7 +3967,7 @@
           <alter>1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3949,7 +3979,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -3957,31 +3987,31 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -3992,7 +4022,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4015,7 +4045,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4034,7 +4064,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4057,7 +4087,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4071,7 +4101,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -4082,7 +4112,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4105,7 +4135,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4124,7 +4154,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4147,7 +4177,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4161,7 +4191,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -4172,7 +4202,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4195,7 +4225,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4214,7 +4244,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4251,7 +4281,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <accidental>flat</accidental>
@@ -4264,7 +4294,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
@@ -4276,7 +4306,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4289,7 +4319,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -4297,14 +4327,14 @@
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="102.50" default-y="-50.00">
         <pitch>
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4318,7 +4348,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4336,7 +4366,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4348,7 +4378,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4360,7 +4390,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4371,7 +4401,7 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="102.50" default-y="-50.00" print-object="no">
         <cue/>
@@ -4379,7 +4409,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="start"/>
         <voice>3</voice>
         <type>eighth</type>
@@ -4396,7 +4426,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <tie type="stop"/>
         <voice>3</voice>
         <type>32nd</type>
@@ -4415,7 +4445,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>3</voice>
         <type>32nd</type>
         <stem>none</stem>
@@ -4430,7 +4460,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>3</voice>
         <type>32nd</type>
         <stem>none</stem>
@@ -4446,7 +4476,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>3</voice>
         <type>32nd</type>
         <stem>none</stem>
@@ -4456,7 +4486,7 @@
         <beam number="3">end</beam>
         </note>
       <backup>
-        <duration>480</duration>
+        <duration>1680</duration>
         </backup>
       <note default-x="102.14" default-y="-170.00">
         <pitch>
@@ -4464,7 +4494,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -4481,7 +4511,7 @@
           <display-step>G</display-step>
           <display-octave>2</display-octave>
           </rest>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -4491,7 +4521,7 @@
           <display-step>G</display-step>
           <display-octave>2</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -4501,7 +4531,7 @@
           <display-step>G</display-step>
           <display-octave>2</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -4514,7 +4544,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4530,7 +4560,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -4543,7 +4573,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4555,7 +4585,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4566,7 +4596,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4581,7 +4611,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4594,7 +4624,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4602,31 +4632,31 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -4637,7 +4667,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4660,7 +4690,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4679,7 +4709,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4702,7 +4732,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4716,7 +4746,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -4727,7 +4757,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4750,7 +4780,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4769,7 +4799,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4792,7 +4822,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -4806,7 +4836,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -4817,7 +4847,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4840,7 +4870,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4859,7 +4889,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -4891,7 +4921,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4907,7 +4937,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4919,7 +4949,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4931,7 +4961,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4943,7 +4973,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4954,7 +4984,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4969,7 +4999,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -4981,14 +5011,14 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-170.00">
         <pitch>
@@ -4996,7 +5026,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5010,21 +5040,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -5045,7 +5075,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
@@ -5058,7 +5088,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
@@ -5071,7 +5101,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
@@ -5084,7 +5114,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5100,7 +5130,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5112,7 +5142,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5123,7 +5153,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5136,7 +5166,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5148,7 +5178,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5160,7 +5190,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5176,7 +5206,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5188,25 +5218,25 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -5216,7 +5246,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5238,7 +5268,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5256,7 +5286,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5278,7 +5308,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5298,7 +5328,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -5308,7 +5338,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5330,7 +5360,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5348,7 +5378,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5370,7 +5400,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -5384,7 +5414,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -5415,7 +5445,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -5432,7 +5462,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -5445,7 +5475,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -5458,7 +5488,7 @@
           <alter>1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <accidental>sharp</accidental>
@@ -5476,7 +5506,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -5488,7 +5518,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <accidental>natural</accidental>
@@ -5500,7 +5530,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5518,7 +5548,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5530,7 +5560,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5541,7 +5571,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5557,7 +5587,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5569,7 +5599,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5580,7 +5610,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5593,7 +5623,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5605,7 +5635,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -5625,7 +5655,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5641,7 +5671,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5653,25 +5683,25 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -5681,7 +5711,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5703,7 +5733,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5721,7 +5751,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5743,7 +5773,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5763,7 +5793,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -5773,7 +5803,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5795,7 +5825,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5813,7 +5843,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -5835,7 +5865,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -5849,7 +5879,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -5868,7 +5898,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -5885,7 +5915,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -5898,7 +5928,7 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <accidental>sharp</accidental>
@@ -5917,7 +5947,7 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <accidental>sharp</accidental>
@@ -5929,7 +5959,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -5948,7 +5978,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5959,7 +5989,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5975,7 +6005,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5987,7 +6017,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -5998,7 +6028,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6011,7 +6041,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -6024,7 +6054,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6035,7 +6065,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6051,7 +6081,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6064,21 +6094,21 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="39.62" default-y="-50.00" dynamics="65.56">
         <pitch>
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>2</voice>
         <type>quarter</type>
@@ -6093,7 +6123,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>2</voice>
         <type>eighth</type>
@@ -6104,18 +6134,18 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -6125,7 +6155,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6147,7 +6177,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6165,7 +6195,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6187,7 +6217,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6201,7 +6231,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -6217,7 +6247,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6239,7 +6269,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6257,7 +6287,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6279,7 +6309,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -6293,7 +6323,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -6323,7 +6353,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -6338,7 +6368,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -6350,7 +6380,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <accidental>natural</accidental>
@@ -6366,7 +6396,7 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <accidental>sharp</accidental>
@@ -6378,7 +6408,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6396,7 +6426,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6407,7 +6437,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6420,7 +6450,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6432,7 +6462,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6452,7 +6482,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6465,7 +6495,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6478,7 +6508,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -6492,7 +6522,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6503,7 +6533,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6516,7 +6546,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6529,7 +6559,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6542,21 +6572,21 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="110.50" default-y="-50.00" dynamics="98.89">
         <pitch>
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>2</voice>
         <type>quarter</type>
@@ -6571,7 +6601,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>2</voice>
         <type>eighth</type>
@@ -6582,18 +6612,18 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -6603,7 +6633,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6625,7 +6655,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6643,7 +6673,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6665,7 +6695,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6685,7 +6715,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -6695,7 +6725,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6717,7 +6747,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6735,7 +6765,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6757,7 +6787,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -6771,7 +6801,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -6781,7 +6811,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6803,7 +6833,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6821,7 +6851,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -6860,7 +6890,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -6876,7 +6906,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6888,7 +6918,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6899,7 +6929,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -6914,7 +6944,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -6926,7 +6956,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -6943,7 +6973,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6959,7 +6989,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6971,7 +7001,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6982,7 +7012,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -6995,7 +7025,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7007,7 +7037,7 @@
           <step>B</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -7019,7 +7049,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7035,7 +7065,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7047,7 +7077,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7060,7 +7090,7 @@
         <staff>1</staff>
         </direction>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <direction placement="above">
         <direction-type>
@@ -7070,14 +7100,14 @@
         </direction>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -7087,7 +7117,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -7104,7 +7134,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -7127,7 +7157,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7147,7 +7177,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -7157,7 +7187,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -7174,7 +7204,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -7191,7 +7221,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -7205,7 +7235,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -7223,7 +7253,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7238,7 +7268,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -7251,7 +7281,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7262,7 +7292,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -7277,7 +7307,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -7289,7 +7319,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -7306,7 +7336,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7322,7 +7352,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7334,7 +7364,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7345,7 +7375,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7358,7 +7388,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7370,7 +7400,7 @@
           <step>B</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -7388,7 +7418,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7404,7 +7434,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7416,14 +7446,14 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <direction placement="above">
         <direction-type>
@@ -7433,14 +7463,14 @@
         </direction>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -7450,7 +7480,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -7467,7 +7497,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -7490,7 +7520,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7504,7 +7534,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -7520,7 +7550,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -7537,7 +7567,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -7554,7 +7584,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -7568,7 +7598,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -7606,7 +7636,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7618,7 +7648,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -7631,7 +7661,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -7642,7 +7672,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -7654,7 +7684,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -7666,7 +7696,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -7677,7 +7707,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -7689,7 +7719,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -7701,7 +7731,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -7713,7 +7743,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -7729,7 +7759,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -7745,7 +7775,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -7756,18 +7786,18 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -7777,7 +7807,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -7794,7 +7824,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -7811,7 +7841,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -7825,7 +7855,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -7835,7 +7865,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -7852,7 +7882,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -7869,7 +7899,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -7883,7 +7913,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -7893,7 +7923,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -7910,7 +7940,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -7930,7 +7960,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -7946,7 +7976,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -7962,7 +7992,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -7974,21 +8004,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <staff>1</staff>
@@ -7998,7 +8028,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -8017,7 +8047,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -8037,7 +8067,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -8056,7 +8086,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -8075,7 +8105,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -8095,7 +8125,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -8110,14 +8140,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-147.76">
         <pitch>
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8142,7 +8172,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8157,7 +8187,7 @@
           <step>B</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -8171,7 +8201,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -8184,7 +8214,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8196,7 +8226,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8207,14 +8237,14 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note default-x="124.69" default-y="-112.76">
         <pitch>
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -8226,7 +8256,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>6</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -8248,7 +8278,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -8271,7 +8301,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -8289,7 +8319,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -8303,7 +8333,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -8317,7 +8347,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -8327,11 +8357,11 @@
         <beam number="3">backward hook</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -8341,7 +8371,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -8352,21 +8382,21 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.94" default-y="-167.76">
         <pitch>
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -8383,7 +8413,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8398,7 +8428,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8411,7 +8441,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8422,7 +8452,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8435,7 +8465,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8448,7 +8478,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8459,7 +8489,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8476,7 +8506,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -8491,7 +8521,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -8509,7 +8539,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -8524,7 +8554,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -8538,7 +8568,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -8548,11 +8578,11 @@
         <beam number="3">backward hook</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -8562,7 +8592,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -8573,7 +8603,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8588,7 +8618,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8599,14 +8629,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-122.76">
         <pitch>
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8622,7 +8652,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8633,7 +8663,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8645,7 +8675,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8658,7 +8688,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8669,7 +8699,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8681,7 +8711,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8694,7 +8724,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8723,7 +8753,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
@@ -8737,7 +8767,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -8750,7 +8780,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -8763,7 +8793,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -8776,7 +8806,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -8788,14 +8818,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>G</display-step>
           <display-octave>4</display-octave>
           </rest>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -8805,7 +8835,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8819,7 +8849,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -8833,21 +8863,21 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="94.27" default-y="-186.97">
         <pitch>
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -8864,7 +8894,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8879,7 +8909,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8892,7 +8922,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8903,7 +8933,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8915,7 +8945,7 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -8929,7 +8959,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8940,7 +8970,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -8957,7 +8987,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -8975,7 +9005,7 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>sharp</accidental>
@@ -8993,7 +9023,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9001,14 +9031,14 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <staff>1</staff>
@@ -9026,7 +9056,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -9045,7 +9075,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -9064,7 +9094,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -9084,7 +9114,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -9103,7 +9133,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -9123,7 +9153,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -9143,7 +9173,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -9158,14 +9188,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="14.36" default-y="-50.00">
         <pitch>
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>2</voice>
         <type>quarter</type>
@@ -9180,7 +9210,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>2</voice>
         <type>eighth</type>
@@ -9191,14 +9221,14 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note default-x="14.36" default-y="-141.97">
         <pitch>
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -9214,7 +9244,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9226,7 +9256,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9240,7 +9270,7 @@
           <step>A</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9256,7 +9286,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9268,7 +9298,7 @@
           <step>G</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9279,14 +9309,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="14.36" default-y="-171.97">
         <pitch>
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>6</voice>
         <type>quarter</type>
         <dot/>
@@ -9294,7 +9324,7 @@
         <staff>2</staff>
         </note>
       <forward>
-        <duration>720</duration>
+        <duration>2520</duration>
         </forward>
       </measure>
     <measure number="35" width="211.61">
@@ -9312,7 +9342,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -9327,7 +9357,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -9345,7 +9375,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -9359,7 +9389,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -9373,7 +9403,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -9383,11 +9413,11 @@
         <beam number="3">backward hook</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>2</voice>
         <type>eighth</type>
         <dot/>
@@ -9398,7 +9428,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>2</voice>
         <type>16th</type>
         <accidental>natural</accidental>
@@ -9410,21 +9440,21 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.20" default-y="-171.97">
         <pitch>
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9441,7 +9471,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9456,7 +9486,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9469,7 +9499,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9480,7 +9510,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9493,7 +9523,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9506,7 +9536,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9517,7 +9547,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9534,7 +9564,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -9549,7 +9579,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -9568,7 +9598,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -9585,7 +9615,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -9602,7 +9632,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9614,7 +9644,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -9626,11 +9656,11 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>2</voice>
         <type>eighth</type>
         <dot/>
@@ -9641,7 +9671,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>2</voice>
         <type>16th</type>
         <accidental>natural</accidental>
@@ -9653,7 +9683,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -9664,7 +9694,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9679,7 +9709,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9690,14 +9720,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-126.97">
         <pitch>
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9713,7 +9743,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9724,7 +9754,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9736,7 +9766,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9749,7 +9779,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9760,7 +9790,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9772,7 +9802,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9785,7 +9815,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -9822,7 +9852,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
@@ -9836,7 +9866,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -9846,14 +9876,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="90.84" default-y="-142.59">
         <pitch>
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9868,7 +9898,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9881,7 +9911,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9892,7 +9922,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9905,7 +9935,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9916,7 +9946,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9929,7 +9959,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9940,7 +9970,7 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -9954,7 +9984,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9965,7 +9995,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -9981,21 +10011,21 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="90.47" default-y="-167.59">
         <pitch>
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>6</voice>
         <type>half</type>
         <stem>down</stem>
@@ -10006,7 +10036,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -10019,7 +10049,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -10031,7 +10061,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -10043,7 +10073,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -10051,21 +10081,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -10084,14 +10114,14 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <direction placement="above">
         <direction-type>
@@ -10107,7 +10137,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -10119,7 +10149,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -10127,7 +10157,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -10146,7 +10176,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10167,7 +10197,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10185,7 +10215,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10206,7 +10236,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -10220,7 +10250,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -10230,7 +10260,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10251,7 +10281,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10269,7 +10299,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10290,7 +10320,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -10304,7 +10334,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -10316,7 +10346,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -10331,7 +10361,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
@@ -10348,21 +10378,21 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>E</display-step>
           <display-octave>4</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -10372,7 +10402,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <stem>down</stem>
@@ -10384,7 +10414,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <stem>down</stem>
@@ -10397,7 +10427,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <accidental>flat</accidental>
@@ -10405,18 +10435,18 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -10426,7 +10456,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10447,7 +10477,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10465,7 +10495,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10486,7 +10516,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -10500,7 +10530,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -10510,7 +10540,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10539,7 +10569,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10557,7 +10587,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10578,7 +10608,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -10592,7 +10622,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -10617,7 +10647,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -10635,7 +10665,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>half</type>
@@ -10647,14 +10677,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>E</display-step>
           <display-octave>4</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -10664,7 +10694,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <stem>down</stem>
@@ -10677,21 +10707,21 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>960</duration>
+        <duration>3360</duration>
         </backup>
       <note default-x="277.24" default-y="-25.00">
         <pitch>
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>3</voice>
         <type>quarter</type>
         <dot/>
@@ -10703,25 +10733,25 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>3</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -10731,7 +10761,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10752,7 +10782,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10770,7 +10800,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10791,7 +10821,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -10805,7 +10835,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -10815,7 +10845,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10836,7 +10866,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10854,7 +10884,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -10875,7 +10905,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -10889,7 +10919,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -10901,7 +10931,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -10917,7 +10947,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>half</type>
@@ -10929,14 +10959,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>E</display-step>
           <display-octave>4</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -10947,7 +10977,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <stem>down</stem>
@@ -10960,7 +10990,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <accidental>flat</accidental>
@@ -10968,14 +10998,14 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>960</duration>
+        <duration>3360</duration>
         </backup>
       <note default-x="186.40" default-y="-15.00">
         <pitch>
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>3</voice>
         <type>quarter</type>
         <dot/>
@@ -10987,25 +11017,25 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>3</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -11015,7 +11045,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11036,7 +11066,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11054,7 +11084,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11075,7 +11105,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -11089,7 +11119,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -11099,7 +11129,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11120,7 +11150,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11138,7 +11168,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11159,7 +11189,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -11173,7 +11203,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -11197,7 +11227,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -11221,7 +11251,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -11239,7 +11269,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>16th</type>
@@ -11256,7 +11286,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11270,7 +11300,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11285,7 +11315,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11307,7 +11337,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11321,7 +11351,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11335,7 +11365,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11349,7 +11379,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -11365,7 +11395,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -11380,7 +11410,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11394,7 +11424,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11409,7 +11439,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11423,7 +11453,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11438,7 +11468,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11452,7 +11482,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11462,18 +11492,18 @@
         <beam number="3">end</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -11483,7 +11513,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11506,7 +11536,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11521,7 +11551,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11539,7 +11569,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11562,7 +11592,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -11577,7 +11607,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -11591,14 +11621,14 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -11620,7 +11650,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -11628,7 +11658,7 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-189.18">
         <pitch>
@@ -11636,7 +11666,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -11650,7 +11680,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -11658,14 +11688,14 @@
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="14.16" default-y="-144.18">
         <pitch>
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>6</voice>
         <type>eighth</type>
         <dot/>
@@ -11683,7 +11713,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>6</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -11697,7 +11727,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -11711,21 +11741,21 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="26.03" default-y="-144.18">
         <pitch>
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>7</voice>
         <type>half</type>
         <dot/>
@@ -11739,7 +11769,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -11754,7 +11784,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -11774,7 +11804,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -11791,7 +11821,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -11802,7 +11832,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -11815,14 +11845,14 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="40.17" default-y="-5.00" print-object="no">
         <cue/>
@@ -11831,7 +11861,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -11854,7 +11884,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -11874,7 +11904,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -11892,7 +11922,7 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="10.36" default-y="-154.18">
         <pitch>
@@ -11900,7 +11930,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>down</stem>
@@ -11912,7 +11942,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>down</stem>
@@ -11924,7 +11954,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>down</stem>
@@ -11936,7 +11966,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -11948,7 +11978,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -11961,7 +11991,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -11975,7 +12005,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -11988,7 +12018,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -11996,7 +12026,7 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="14.16" default-y="-139.18">
         <pitch>
@@ -12004,7 +12034,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -12021,7 +12051,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -12036,7 +12066,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -12052,14 +12082,14 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-189.18">
         <pitch>
@@ -12067,7 +12097,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>6</voice>
         <type>half</type>
         <dot/>
@@ -12080,7 +12110,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>6</voice>
         <type>half</type>
         <dot/>
@@ -12093,7 +12123,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>6</voice>
         <type>half</type>
         <dot/>
@@ -12119,7 +12149,7 @@
           <step>A</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -12134,7 +12164,7 @@
           <step>A</step>
           <octave>5</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -12154,7 +12184,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -12171,7 +12201,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -12182,7 +12212,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -12195,14 +12225,14 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="136.06" default-y="15.00" print-object="no">
         <cue/>
@@ -12211,7 +12241,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -12234,7 +12264,7 @@
           <step>A</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -12254,7 +12284,7 @@
           <step>G</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -12272,14 +12302,14 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="101.78" default-y="-134.25">
         <pitch>
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>up</stem>
@@ -12292,7 +12322,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>up</stem>
@@ -12303,14 +12333,14 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="102.14" default-y="-149.25">
         <pitch>
@@ -12318,7 +12348,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -12333,7 +12363,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -12347,7 +12377,7 @@
           <step>A</step>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -12360,7 +12390,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -12373,7 +12403,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -12381,7 +12411,7 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="16.63" default-y="-144.25">
         <pitch>
@@ -12389,7 +12419,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -12408,7 +12438,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -12423,7 +12453,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -12439,14 +12469,14 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="16.27" default-y="-209.25">
         <pitch>
@@ -12454,7 +12484,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>6</voice>
         <type>half</type>
         <dot/>
@@ -12468,7 +12498,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>6</voice>
         <type>half</type>
         <dot/>
@@ -12496,7 +12526,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -12511,7 +12541,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -12531,7 +12561,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -12548,7 +12578,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -12568,7 +12598,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -12581,14 +12611,14 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="84.46" default-y="-5.00" print-object="no">
         <cue/>
@@ -12597,7 +12627,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -12620,7 +12650,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -12640,7 +12670,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -12658,14 +12688,14 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="54.45" default-y="-179.25">
         <pitch>
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>up</stem>
@@ -12678,7 +12708,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <accidental>flat</accidental>
@@ -12697,14 +12727,14 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="54.81" default-y="-194.25">
         <pitch>
@@ -12712,7 +12742,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -12728,7 +12758,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -12742,7 +12772,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -12772,7 +12802,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -12787,7 +12817,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -12802,7 +12832,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -12814,7 +12844,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -12832,7 +12862,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -12846,14 +12876,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.00" default-y="-30.00" dynamics="61.11">
         <pitch>
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>2</voice>
         <type>quarter</type>
         <dot/>
@@ -12866,7 +12896,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -12880,7 +12910,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -12893,7 +12923,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -12901,7 +12931,7 @@
         <beam number="1">end</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.00" default-y="-139.25" dynamics="61.11">
         <pitch>
@@ -12909,7 +12939,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -12924,7 +12954,7 @@
           <step>B</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -12937,7 +12967,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -12952,7 +12982,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -12965,7 +12995,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -12977,7 +13007,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -12986,7 +13016,7 @@
         <beam number="1">end</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.00" default-y="-159.25" dynamics="61.11">
         <pitch>
@@ -12994,7 +13024,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>6</voice>
         <type>quarter</type>
         <dot/>
@@ -13006,7 +13036,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>6</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -13018,7 +13048,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>6</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -13036,7 +13066,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>6</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -13068,7 +13098,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -13112,7 +13142,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -13125,7 +13155,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -13141,7 +13171,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -13149,7 +13179,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -13162,7 +13192,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <staff>1</staff>
@@ -13172,7 +13202,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13189,7 +13219,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13203,7 +13233,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13217,7 +13247,7 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -13232,7 +13262,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13247,7 +13277,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -13263,7 +13293,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13274,7 +13304,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13292,14 +13322,14 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="113.85" default-y="-20.00" dynamics="77.78">
         <pitch>
@@ -13307,7 +13337,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -13321,7 +13351,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -13331,7 +13361,7 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note default-x="101.99" default-y="-10.00" print-object="no" dynamics="77.78">
         <cue/>
@@ -13339,7 +13369,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -13355,7 +13385,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -13371,7 +13401,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -13387,7 +13417,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -13403,7 +13433,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -13419,7 +13449,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -13435,7 +13465,7 @@
           <step>B</step>
           <octave>4</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <accidental>natural</accidental>
@@ -13452,7 +13482,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -13463,14 +13493,14 @@
         <beam number="4">end</beam>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="101.99" default-y="-126.48">
         <pitch>
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <accidental>natural</accidental>
@@ -13485,7 +13515,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -13496,27 +13526,27 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="101.99" default-y="-156.48">
         <pitch>
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>6</voice>
         <type>quarter</type>
         <dot/>
@@ -13528,14 +13558,14 @@
           <display-step>B</display-step>
           <display-octave>4</display-octave>
           </rest>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>6</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -13548,7 +13578,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -13556,7 +13586,7 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-30.00">
         <pitch>
@@ -13564,7 +13594,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>2</voice>
         <type>eighth</type>
         <dot/>
@@ -13582,7 +13612,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>2</voice>
         <type>eighth</type>
         <dot/>
@@ -13595,7 +13625,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>2</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13611,7 +13641,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>2</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13622,7 +13652,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -13637,7 +13667,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -13648,7 +13678,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -13660,14 +13690,14 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-211.48">
         <pitch>
@@ -13675,7 +13705,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -13689,7 +13719,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -13702,7 +13732,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <staff>2</staff>
@@ -13713,7 +13743,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13727,7 +13757,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13742,7 +13772,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13756,7 +13786,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13771,7 +13801,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13785,7 +13815,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13799,7 +13829,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -13814,7 +13844,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -13828,7 +13858,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -13842,7 +13872,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -13857,7 +13887,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -13871,7 +13901,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -13885,7 +13915,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -13900,7 +13930,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -13914,7 +13944,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -13952,7 +13982,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -13967,7 +13997,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -13987,7 +14017,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14004,7 +14034,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -14022,14 +14052,14 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="225.36" default-y="-5.00" print-object="no">
         <cue/>
@@ -14038,7 +14068,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -14061,7 +14091,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -14081,7 +14111,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -14099,14 +14129,14 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="111.89" default-y="-115.00">
         <pitch>
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14121,7 +14151,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14135,7 +14165,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14149,7 +14179,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14164,7 +14194,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14178,7 +14208,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14192,7 +14222,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14207,7 +14237,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14221,7 +14251,7 @@
           <step>D</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14236,7 +14266,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14250,7 +14280,7 @@
           <step>D</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14264,7 +14294,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14279,7 +14309,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14293,7 +14323,7 @@
           <step>D</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14307,7 +14337,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14322,7 +14352,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14336,7 +14366,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14351,7 +14381,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14365,7 +14395,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14379,7 +14409,7 @@
           <step>D</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14394,7 +14424,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14408,7 +14438,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14422,7 +14452,7 @@
           <step>D</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14437,7 +14467,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -14465,7 +14495,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
@@ -14473,14 +14503,14 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="94.27" default-y="-25.00">
         <pitch>
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>2</voice>
         <type>eighth</type>
         <dot/>
@@ -14496,7 +14526,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>2</voice>
         <type>eighth</type>
         <dot/>
@@ -14509,7 +14539,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>2</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14524,7 +14554,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>2</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14536,7 +14566,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -14549,7 +14579,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -14562,7 +14592,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -14575,21 +14605,21 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="94.27" default-y="-185.00">
         <pitch>
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -14603,7 +14633,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -14616,7 +14646,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <staff>2</staff>
@@ -14626,7 +14656,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14641,7 +14671,7 @@
           <alter>-1</alter>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14655,7 +14685,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14669,7 +14699,7 @@
           <step>A</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14683,7 +14713,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14698,7 +14728,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -14713,7 +14743,7 @@
           <step>A</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14728,7 +14758,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14743,7 +14773,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14757,7 +14787,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14772,7 +14802,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14786,7 +14816,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14800,7 +14830,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14815,7 +14845,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -14830,7 +14860,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14868,7 +14898,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -14883,7 +14913,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -14902,7 +14932,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -14920,7 +14950,7 @@
           <alter>-1</alter>
           <octave>6</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -14939,7 +14969,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -14952,7 +14982,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -14965,7 +14995,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -14973,7 +15003,7 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="228.44" default-y="25.00" print-object="no">
         <cue/>
@@ -14981,7 +15011,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -15004,7 +15034,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -15024,7 +15054,7 @@
           <step>B</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <accidental>natural</accidental>
@@ -15043,7 +15073,7 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="111.89" default-y="-85.00">
         <pitch>
@@ -15051,7 +15081,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15066,7 +15096,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -15081,7 +15111,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15096,7 +15126,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15110,7 +15140,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15124,7 +15154,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15139,7 +15169,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -15154,7 +15184,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15168,7 +15198,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15183,7 +15213,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15198,7 +15228,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15212,7 +15242,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15227,7 +15257,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15241,7 +15271,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15255,7 +15285,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15270,7 +15300,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15281,7 +15311,7 @@
         </note>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <staff>2</staff>
@@ -15292,7 +15322,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15307,7 +15337,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15322,7 +15352,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15337,7 +15367,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15352,7 +15382,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15367,7 +15397,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15382,7 +15412,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15410,7 +15440,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>down</stem>
@@ -15421,7 +15451,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -15429,7 +15459,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <staff>1</staff>
@@ -15439,21 +15469,21 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="102.34" default-y="-50.00">
         <pitch>
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -15467,7 +15497,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -15478,7 +15508,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>2</voice>
         <type>16th</type>
         <dot/>
@@ -15493,7 +15523,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>2</voice>
         <type>16th</type>
         <dot/>
@@ -15505,7 +15535,7 @@
           <step>B</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>2</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -15521,7 +15551,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>2</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15532,7 +15562,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -15545,7 +15575,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -15556,7 +15586,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -15569,21 +15599,21 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1200</duration>
+        <duration>4200</duration>
         </backup>
       <note default-x="102.70" default-y="-160.00">
         <pitch>
           <step>A</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -15591,7 +15621,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -15604,7 +15634,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <staff>2</staff>
@@ -15614,7 +15644,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15629,7 +15659,7 @@
           <alter>-1</alter>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15643,7 +15673,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15657,7 +15687,7 @@
           <step>A</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15671,7 +15701,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15686,7 +15716,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15700,7 +15730,7 @@
           <step>A</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15714,7 +15744,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -15729,7 +15759,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -15743,7 +15773,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -15757,7 +15787,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -15772,7 +15802,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -15786,7 +15816,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -15800,7 +15830,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -15815,7 +15845,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -15849,7 +15879,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -15864,7 +15894,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -15883,7 +15913,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -15901,7 +15931,7 @@
           <alter>-1</alter>
           <octave>6</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -15912,7 +15942,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -15927,7 +15957,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -15940,14 +15970,14 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="227.04" default-y="25.00" print-object="no">
         <cue/>
@@ -15955,7 +15985,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -15978,7 +16008,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -15998,7 +16028,7 @@
           <step>B</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <accidental>natural</accidental>
@@ -16017,14 +16047,14 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="110.30" default-y="-105.00">
         <pitch>
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16038,7 +16068,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16052,7 +16082,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16066,7 +16096,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16080,7 +16110,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16094,7 +16124,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16108,7 +16138,7 @@
           <step>A</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16122,7 +16152,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16136,7 +16166,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16150,7 +16180,7 @@
           <step>A</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16164,7 +16194,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16178,7 +16208,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16192,7 +16222,7 @@
           <step>A</step>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16206,7 +16236,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16220,7 +16250,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16234,7 +16264,7 @@
           <step>A</step>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16245,7 +16275,7 @@
         </note>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <staff>2</staff>
@@ -16256,7 +16286,7 @@
           <alter>1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>sharp</accidental>
@@ -16271,7 +16301,7 @@
           <step>A</step>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16285,7 +16315,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16300,7 +16330,7 @@
           <alter>1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>sharp</accidental>
@@ -16315,7 +16345,7 @@
           <step>A</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16329,7 +16359,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16344,7 +16374,7 @@
           <alter>1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>sharp</accidental>
@@ -16374,7 +16404,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -16389,7 +16419,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -16397,7 +16427,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -16416,18 +16446,18 @@
           <step>G</step>
           <octave>5</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>960</duration>
+        <duration>3360</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -16446,7 +16476,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -16459,7 +16489,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -16472,7 +16502,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -16481,17 +16511,17 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <staff>2</staff>
@@ -16501,7 +16531,7 @@
           <step>G</step>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16516,7 +16546,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16530,7 +16560,7 @@
           <step>D</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16544,7 +16574,7 @@
           <step>G</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16559,7 +16589,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16573,7 +16603,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16587,7 +16617,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16598,7 +16628,7 @@
         </note>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <staff>2</staff>
@@ -16608,7 +16638,7 @@
           <step>E</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -16623,7 +16653,7 @@
           <step>G</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16638,7 +16668,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16652,7 +16682,7 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -16667,7 +16697,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16682,7 +16712,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16696,7 +16726,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -16711,7 +16741,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -16727,7 +16757,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16741,7 +16771,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16755,7 +16785,7 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16770,7 +16800,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -16786,7 +16816,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16800,7 +16830,7 @@
           <step>G</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16814,7 +16844,7 @@
           <step>E</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -16851,7 +16881,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
@@ -16862,7 +16892,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -16875,7 +16905,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -16887,7 +16917,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -16899,7 +16929,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -16907,20 +16937,20 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>D</display-step>
           <display-octave>5</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -16939,7 +16969,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -16952,7 +16982,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -16964,7 +16994,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -16973,17 +17003,17 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>960</duration>
+        <duration>3360</duration>
         </backup>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <staff>2</staff>
@@ -16993,7 +17023,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17008,7 +17038,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17022,7 +17052,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -17037,7 +17067,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17051,7 +17081,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17066,7 +17096,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17080,7 +17110,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17091,7 +17121,7 @@
         </note>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <staff>2</staff>
@@ -17101,7 +17131,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17116,7 +17146,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17130,7 +17160,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17144,7 +17174,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17158,7 +17188,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17173,7 +17203,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17187,7 +17217,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17202,7 +17232,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -17217,7 +17247,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17231,7 +17261,7 @@
           <step>A</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17245,7 +17275,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17260,7 +17290,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17274,7 +17304,7 @@
           <step>C</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17288,7 +17318,7 @@
           <step>A</step>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17302,7 +17332,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -17319,7 +17349,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17331,7 +17361,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17343,7 +17373,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17356,7 +17386,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17364,27 +17394,27 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-170.00">
         <pitch>
@@ -17392,7 +17422,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17400,7 +17430,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -17411,7 +17441,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17434,7 +17464,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17453,7 +17483,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17476,7 +17506,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17490,7 +17520,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -17501,7 +17531,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17524,7 +17554,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17543,7 +17573,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17566,7 +17596,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17580,7 +17610,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -17591,7 +17621,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17614,7 +17644,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17633,7 +17663,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17658,7 +17688,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -17675,7 +17705,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -17687,7 +17717,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -17698,7 +17728,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -17711,7 +17741,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -17724,7 +17754,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -17736,7 +17766,7 @@
           <alter>1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>sharp</accidental>
@@ -17753,7 +17783,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -17765,14 +17795,14 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="18.27" default-y="-170.00">
         <pitch>
@@ -17780,7 +17810,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17794,21 +17824,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -17833,7 +17863,7 @@
           <alter>1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>sharp</accidental>
@@ -17850,7 +17880,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -17862,7 +17892,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -17873,7 +17903,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17889,7 +17919,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17902,7 +17932,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -17910,31 +17940,31 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -17945,7 +17975,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17968,7 +17998,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -17987,7 +18017,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18010,7 +18040,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -18024,7 +18054,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -18035,7 +18065,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18058,7 +18088,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18077,7 +18107,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18100,7 +18130,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -18114,7 +18144,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -18125,7 +18155,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18148,7 +18178,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18167,7 +18197,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18192,7 +18222,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18204,7 +18234,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18217,7 +18247,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -18230,7 +18260,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18243,7 +18273,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18255,7 +18285,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18267,7 +18297,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18279,7 +18309,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18292,7 +18322,7 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>sharp</accidental>
@@ -18300,7 +18330,7 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="16.27" default-y="-177.14">
         <pitch>
@@ -18308,7 +18338,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -18322,21 +18352,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -18348,7 +18378,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18364,7 +18394,7 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>sharp</accidental>
@@ -18377,7 +18407,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -18394,7 +18424,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -18410,7 +18440,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -18427,7 +18457,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -18442,7 +18472,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -18450,7 +18480,7 @@
         <beam number="1">end</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="18.42" default-y="-55.00">
         <pitch>
@@ -18458,7 +18488,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <tie type="start"/>
         <voice>2</voice>
         <type>half</type>
@@ -18474,7 +18504,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>2</voice>
         <type>eighth</type>
@@ -18485,18 +18515,18 @@
           </notations>
         </note>
       <backup>
-        <duration>1200</duration>
+        <duration>4200</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -18507,7 +18537,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18530,7 +18560,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18549,7 +18579,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18572,7 +18602,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -18586,7 +18616,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -18597,7 +18627,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18620,7 +18650,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18639,7 +18669,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18662,7 +18692,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -18676,7 +18706,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -18687,7 +18717,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18710,7 +18740,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18729,7 +18759,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -18761,7 +18791,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -18777,7 +18807,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -18789,7 +18819,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18801,7 +18831,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18813,7 +18843,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18824,7 +18854,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18839,7 +18869,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -18852,14 +18882,14 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-177.14">
         <pitch>
@@ -18867,7 +18897,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -18881,21 +18911,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -18919,7 +18949,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
@@ -18932,7 +18962,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
@@ -18945,7 +18975,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
@@ -18957,7 +18987,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -18973,7 +19003,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -18985,7 +19015,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -18996,7 +19026,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19009,7 +19039,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19022,7 +19052,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19034,7 +19064,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19050,7 +19080,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19062,25 +19092,25 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -19091,7 +19121,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19114,7 +19144,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19133,7 +19163,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19156,7 +19186,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19176,7 +19206,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -19186,7 +19216,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19208,7 +19238,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19226,7 +19256,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19248,7 +19278,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -19262,7 +19292,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -19281,7 +19311,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -19295,7 +19325,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -19308,7 +19338,7 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <accidental>sharp</accidental>
@@ -19323,7 +19353,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -19334,7 +19364,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19353,7 +19383,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19364,7 +19394,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19380,7 +19410,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19393,7 +19423,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19412,7 +19442,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19425,7 +19455,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19437,7 +19467,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -19449,7 +19479,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19466,7 +19496,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19478,21 +19508,21 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="39.62" default-y="-35.00">
         <pitch>
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>2</voice>
         <type>quarter</type>
         <dot/>
@@ -19500,18 +19530,18 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -19522,7 +19552,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19545,7 +19575,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19564,7 +19594,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19587,7 +19617,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19607,7 +19637,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -19617,7 +19647,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19639,7 +19669,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19657,7 +19687,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19679,7 +19709,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -19693,7 +19723,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -19712,7 +19742,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -19726,7 +19756,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -19739,7 +19769,7 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <accidental>sharp</accidental>
@@ -19754,7 +19784,7 @@
           <step>B</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <accidental>natural</accidental>
@@ -19766,7 +19796,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19784,7 +19814,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19795,7 +19825,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19811,7 +19841,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19823,7 +19853,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19834,7 +19864,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19848,7 +19878,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -19861,7 +19891,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19872,7 +19902,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19888,7 +19918,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -19901,21 +19931,21 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="39.62" default-y="-35.00" dynamics="65.56">
         <pitch>
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>2</voice>
         <type>quarter</type>
@@ -19930,7 +19960,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>2</voice>
         <type>eighth</type>
@@ -19941,18 +19971,18 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -19963,7 +19993,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -19986,7 +20016,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20005,7 +20035,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20028,7 +20058,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20042,7 +20072,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -20058,7 +20088,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20080,7 +20110,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20098,7 +20128,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20120,7 +20150,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20134,7 +20164,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -20164,7 +20194,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -20179,7 +20209,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -20191,7 +20221,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -20206,7 +20236,7 @@
           <alter>1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <accidental>sharp</accidental>
@@ -20219,7 +20249,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20237,7 +20267,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20248,7 +20278,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20262,7 +20292,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20274,7 +20304,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20294,7 +20324,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20308,7 +20338,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20321,7 +20351,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -20334,7 +20364,7 @@
           <step>E</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -20346,7 +20376,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20360,7 +20390,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20373,7 +20403,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20385,21 +20415,21 @@
           <step>E</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="110.50" default-y="-35.00" dynamics="98.89">
         <pitch>
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>2</voice>
         <type>quarter</type>
@@ -20414,7 +20444,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>2</voice>
         <type>eighth</type>
@@ -20425,18 +20455,18 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -20447,7 +20477,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20470,7 +20500,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20489,7 +20519,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20512,7 +20542,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -20526,7 +20556,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -20542,7 +20572,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20564,7 +20594,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20582,7 +20612,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20604,7 +20634,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20618,7 +20648,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -20628,7 +20658,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20650,7 +20680,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20668,7 +20698,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -20707,7 +20737,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20722,7 +20752,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20734,7 +20764,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20751,7 +20781,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -20766,7 +20796,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -20778,7 +20808,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -20801,7 +20831,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20817,7 +20847,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20829,7 +20859,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20840,7 +20870,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20854,7 +20884,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20866,7 +20896,7 @@
           <step>E</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -20884,7 +20914,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20901,7 +20931,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20913,25 +20943,25 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -20941,7 +20971,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -20955,7 +20985,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -20969,7 +20999,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -20989,7 +21019,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -20999,7 +21029,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -21013,7 +21043,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -21027,7 +21057,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21041,7 +21071,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -21059,7 +21089,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21074,7 +21104,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21086,7 +21116,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21103,7 +21133,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -21118,7 +21148,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -21130,7 +21160,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -21153,7 +21183,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21169,7 +21199,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21181,7 +21211,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21192,7 +21222,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21206,7 +21236,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21218,7 +21248,7 @@
           <step>E</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -21236,7 +21266,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21253,7 +21283,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21265,25 +21295,25 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -21293,7 +21323,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21307,7 +21337,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21321,7 +21351,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21341,7 +21371,7 @@
         </attributes>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -21351,7 +21381,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -21365,7 +21395,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -21379,7 +21409,7 @@
           <step>F</step>
           <octave>6</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21393,7 +21423,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -21423,7 +21453,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21435,7 +21465,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21447,7 +21477,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21466,7 +21496,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -21478,7 +21508,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -21490,7 +21520,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -21501,7 +21531,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -21513,7 +21543,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -21525,7 +21555,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -21536,7 +21566,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -21552,7 +21582,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -21568,7 +21598,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -21579,18 +21609,18 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -21600,7 +21630,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21614,7 +21644,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21628,7 +21658,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21642,7 +21672,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -21652,7 +21682,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21666,7 +21696,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21680,7 +21710,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21694,7 +21724,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -21704,7 +21734,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21718,7 +21748,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21734,7 +21764,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -21750,7 +21780,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -21766,7 +21796,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -21778,21 +21808,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <staff>1</staff>
@@ -21802,7 +21832,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21821,7 +21851,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21841,7 +21871,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21860,7 +21890,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21879,7 +21909,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21899,7 +21929,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -21914,14 +21944,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-121.19">
         <pitch>
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21946,7 +21976,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -21961,7 +21991,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -21975,7 +22005,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -21988,7 +22018,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22000,7 +22030,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22011,14 +22041,14 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note default-x="126.92" default-y="-86.19">
         <pitch>
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -22030,7 +22060,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>6</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -22060,7 +22090,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -22075,7 +22105,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -22094,7 +22124,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -22109,7 +22139,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -22123,7 +22153,7 @@
           <step>G</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -22136,14 +22166,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>D</display-step>
           <display-octave>5</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -22154,7 +22184,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -22166,14 +22196,14 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.94" default-y="-141.19">
         <pitch>
@@ -22181,7 +22211,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -22193,7 +22223,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22208,7 +22238,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22221,7 +22251,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22233,7 +22263,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22246,7 +22276,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22259,7 +22289,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22271,7 +22301,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22288,7 +22318,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -22303,7 +22333,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -22322,7 +22352,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -22337,7 +22367,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -22351,7 +22381,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -22364,14 +22394,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>D</display-step>
           <display-octave>5</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -22382,7 +22412,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -22394,7 +22424,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22409,7 +22439,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22420,14 +22450,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-96.19">
         <pitch>
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22443,7 +22473,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22455,7 +22485,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22467,7 +22497,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22480,7 +22510,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22492,7 +22522,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22504,7 +22534,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22517,7 +22547,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22547,7 +22577,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
@@ -22561,7 +22591,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -22574,7 +22604,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -22588,7 +22618,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -22601,7 +22631,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -22613,11 +22643,11 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -22627,7 +22657,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22641,7 +22671,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -22655,21 +22685,21 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="90.84" default-y="-172.35">
         <pitch>
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -22680,7 +22710,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22696,7 +22726,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22709,7 +22739,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22720,7 +22750,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22732,7 +22762,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22745,7 +22775,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22756,7 +22786,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -22773,7 +22803,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -22788,7 +22818,7 @@
           <alter>1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>sharp</accidental>
@@ -22803,7 +22833,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -22811,14 +22841,14 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <staff>1</staff>
@@ -22836,7 +22866,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -22855,7 +22885,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -22874,7 +22904,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -22894,7 +22924,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -22913,7 +22943,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -22933,7 +22963,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -22953,7 +22983,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -22968,14 +22998,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.00" default-y="-35.00">
         <pitch>
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>2</voice>
         <type>quarter</type>
@@ -22990,7 +23020,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>2</voice>
         <type>eighth</type>
@@ -23001,14 +23031,14 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note default-x="10.00" default-y="-127.35">
         <pitch>
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23023,7 +23053,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23036,7 +23066,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23050,7 +23080,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23066,7 +23096,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23078,7 +23108,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23089,7 +23119,7 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.00" default-y="-157.35">
         <pitch>
@@ -23097,7 +23127,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>6</voice>
         <type>quarter</type>
         <dot/>
@@ -23105,7 +23135,7 @@
         <staff>2</staff>
         </note>
       <forward>
-        <duration>720</duration>
+        <duration>2520</duration>
         </forward>
       </measure>
     <measure number="77" width="231.77">
@@ -23123,7 +23153,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -23138,7 +23168,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -23157,7 +23187,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -23172,7 +23202,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -23186,7 +23216,7 @@
           <step>G</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -23199,11 +23229,11 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>2</voice>
         <type>eighth</type>
         <dot/>
@@ -23214,7 +23244,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>2</voice>
         <type>16th</type>
         <stem>down</stem>
@@ -23226,14 +23256,14 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.20" default-y="-157.35">
         <pitch>
@@ -23241,7 +23271,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23253,7 +23283,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23268,7 +23298,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23281,7 +23311,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23293,7 +23323,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23306,7 +23336,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23319,7 +23349,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23331,7 +23361,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23348,7 +23378,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -23363,7 +23393,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -23382,7 +23412,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -23397,7 +23427,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -23411,7 +23441,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -23424,14 +23454,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>D</display-step>
           <display-octave>5</display-octave>
           </rest>
-        <duration>360</duration>
+        <duration>1260</duration>
         <voice>2</voice>
         <type>eighth</type>
         <dot/>
@@ -23442,7 +23472,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>2</voice>
         <type>16th</type>
         <stem>down</stem>
@@ -23454,7 +23484,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -23466,7 +23496,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23481,7 +23511,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23492,14 +23522,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-112.35">
         <pitch>
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23515,7 +23545,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23527,7 +23557,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23539,7 +23569,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23552,7 +23582,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23564,7 +23594,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23576,7 +23606,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23589,7 +23619,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23627,7 +23657,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
@@ -23641,7 +23671,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -23651,14 +23681,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="90.84" default-y="-45.00">
         <pitch>
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23674,7 +23704,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23687,7 +23717,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23698,7 +23728,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23711,7 +23741,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23723,7 +23753,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23736,7 +23766,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -23747,7 +23777,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23760,7 +23790,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23771,7 +23801,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23787,21 +23817,21 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="90.47" default-y="-131.56">
         <pitch>
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>5</voice>
         <type>half</type>
         <stem>down</stem>
@@ -23812,7 +23842,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -23824,7 +23854,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -23846,7 +23876,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23859,7 +23889,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23871,7 +23901,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23879,21 +23909,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -23913,14 +23943,14 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-186.56">
         <pitch>
@@ -23928,7 +23958,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -23945,7 +23975,7 @@
         </direction>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -23956,7 +23986,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -23979,7 +24009,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -23998,7 +24028,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24021,7 +24051,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -24035,7 +24065,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -24046,7 +24076,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24069,7 +24099,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24088,7 +24118,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24111,7 +24141,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -24125,7 +24155,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -24138,7 +24168,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -24161,7 +24191,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
@@ -24178,25 +24208,25 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -24207,7 +24237,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24230,7 +24260,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24249,7 +24279,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24272,7 +24302,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -24286,7 +24316,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -24297,7 +24327,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24320,7 +24350,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24339,7 +24369,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24362,7 +24392,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -24376,20 +24406,20 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>960</duration>
+        <duration>3360</duration>
         </backup>
       <note default-x="118.11" default-y="-141.56">
         <pitch>
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>6</voice>
         <type>half</type>
         <stem>up</stem>
@@ -24401,7 +24431,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>6</voice>
         <type>half</type>
         <stem>up</stem>
@@ -24414,7 +24444,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>6</voice>
         <type>half</type>
         <accidental>flat</accidental>
@@ -24429,7 +24459,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -24446,7 +24476,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
@@ -24462,7 +24492,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <accidental>flat</accidental>
@@ -24476,7 +24506,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>half</type>
@@ -24487,14 +24517,14 @@
           </notations>
         </note>
       <backup>
-        <duration>960</duration>
+        <duration>3360</duration>
         </backup>
       <note default-x="128.28" default-y="-45.00">
         <pitch>
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>3</voice>
         <type>quarter</type>
         <dot/>
@@ -24506,25 +24536,25 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>3</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -24535,7 +24565,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24558,7 +24588,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24577,7 +24607,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24600,7 +24630,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -24614,7 +24644,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -24625,7 +24655,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24648,7 +24678,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24667,7 +24697,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24690,7 +24720,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -24704,7 +24734,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -24728,7 +24758,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -24745,7 +24775,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -24759,7 +24789,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -24772,7 +24802,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -24788,7 +24818,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -24800,7 +24830,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -24815,7 +24845,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -24827,7 +24857,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -24840,7 +24870,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -24848,18 +24878,18 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -24870,7 +24900,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24893,7 +24923,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24912,7 +24942,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24935,7 +24965,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -24949,7 +24979,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -24960,7 +24990,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -24983,7 +25013,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25002,7 +25032,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25025,7 +25055,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25039,7 +25069,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -25050,7 +25080,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25073,7 +25103,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25092,7 +25122,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25125,7 +25155,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <accidental>flat</accidental>
@@ -25141,7 +25171,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25154,7 +25184,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25165,11 +25195,11 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -25179,7 +25209,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -25191,7 +25221,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -25204,7 +25234,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -25216,7 +25246,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -25228,14 +25258,14 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="16.27" default-y="-180.80">
         <pitch>
@@ -25243,7 +25273,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25257,7 +25287,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -25268,7 +25298,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -25292,7 +25322,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25311,7 +25341,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25334,7 +25364,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25348,7 +25378,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -25359,7 +25389,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25382,7 +25412,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25401,7 +25431,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25424,7 +25454,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25438,7 +25468,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -25460,7 +25490,7 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>sharp</accidental>
@@ -25483,7 +25513,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
@@ -25499,21 +25529,21 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>E</display-step>
           <display-octave>4</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -25524,7 +25554,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <stem>down</stem>
@@ -25537,25 +25567,25 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -25566,7 +25596,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25589,7 +25619,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25608,7 +25638,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25631,7 +25661,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25645,7 +25675,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -25656,7 +25686,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25679,7 +25709,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25698,7 +25728,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25721,7 +25751,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25735,7 +25765,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -25760,7 +25790,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
@@ -25771,7 +25801,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25783,7 +25813,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25791,14 +25821,14 @@
         <beam number="1">end</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>D</display-step>
           <display-octave>5</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -25816,7 +25846,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>2</voice>
         <type>quarter</type>
@@ -25832,7 +25862,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>2</voice>
         <type>eighth</type>
@@ -25843,7 +25873,7 @@
           </notations>
         </note>
       <backup>
-        <duration>720</duration>
+        <duration>2520</duration>
         </backup>
       <note default-x="208.16" default-y="-40.00">
         <pitch>
@@ -25851,7 +25881,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>3</voice>
         <type>half</type>
         <stem>down</stem>
@@ -25864,7 +25894,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>3</voice>
         <type>half</type>
         <accidental>flat</accidental>
@@ -25872,18 +25902,18 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -25894,7 +25924,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25917,7 +25947,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25936,7 +25966,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -25959,7 +25989,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -25973,7 +26003,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -25984,7 +26014,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26007,7 +26037,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26026,7 +26056,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26049,7 +26079,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26063,7 +26093,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -26084,7 +26114,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -26107,7 +26137,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <tie type="start"/>
         <voice>1</voice>
         <type>quarter</type>
@@ -26124,7 +26154,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <tie type="stop"/>
         <voice>1</voice>
         <type>eighth</type>
@@ -26141,7 +26171,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26152,11 +26182,11 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -26166,7 +26196,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -26181,7 +26211,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -26192,7 +26222,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -26208,7 +26238,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -26216,18 +26246,18 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -26238,7 +26268,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26261,7 +26291,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26280,7 +26310,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26303,7 +26333,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26317,7 +26347,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -26328,7 +26358,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26351,7 +26381,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26370,7 +26400,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26393,7 +26423,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26407,7 +26437,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -26427,7 +26457,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26442,7 +26472,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>720</duration>
+        <duration>2520</duration>
         <voice>1</voice>
         <type>quarter</type>
         <dot/>
@@ -26454,7 +26484,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26466,7 +26496,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26477,14 +26507,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>D</display-step>
           <display-octave>5</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -26494,7 +26524,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -26511,7 +26541,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -26531,7 +26561,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -26548,7 +26578,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -26561,7 +26591,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -26578,7 +26608,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -26590,7 +26620,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -26601,7 +26631,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -26618,7 +26648,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -26631,25 +26661,25 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -26660,7 +26690,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26683,7 +26713,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26702,7 +26732,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26725,7 +26755,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26739,7 +26769,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -26750,7 +26780,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26773,7 +26803,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26792,7 +26822,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26815,7 +26845,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26829,7 +26859,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <staff>2</staff>
@@ -26840,7 +26870,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26863,7 +26893,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26882,7 +26912,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>40</duration>
+        <duration>140</duration>
         <voice>5</voice>
         <type>32nd</type>
         <time-modification>
@@ -26927,7 +26957,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26939,7 +26969,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26952,7 +26982,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -26960,21 +26990,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <staff>1</staff>
@@ -26984,7 +27014,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -27003,7 +27033,7 @@
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -27023,7 +27053,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -27042,7 +27072,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -27062,7 +27092,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -27082,7 +27112,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -27101,7 +27131,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -27116,7 +27146,7 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="90.47" default-y="-154.22">
         <pitch>
@@ -27124,7 +27154,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -27142,7 +27172,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -27155,7 +27185,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -27171,7 +27201,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -27182,7 +27212,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -27194,7 +27224,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -27205,7 +27235,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -27221,14 +27251,14 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="106.64" default-y="-154.22">
         <pitch>
@@ -27236,7 +27266,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>6</voice>
         <type>half</type>
         <dot/>
@@ -27251,7 +27281,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -27269,7 +27299,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>1</voice>
         <type>eighth</type>
         <dot/>
@@ -27282,7 +27312,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>up</stem>
@@ -27298,7 +27328,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -27310,7 +27340,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -27322,7 +27352,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -27333,7 +27363,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -27349,21 +27379,21 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.36" default-y="-35.00">
         <pitch>
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>2</voice>
         <type>half</type>
         <stem>down</stem>
@@ -27374,14 +27404,14 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.72" default-y="-154.22">
         <pitch>
@@ -27389,7 +27419,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -27407,7 +27437,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -27415,21 +27445,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <staff>2</staff>
@@ -27439,7 +27469,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -27458,7 +27488,7 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -27478,7 +27508,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -27497,7 +27527,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -27516,7 +27546,7 @@
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -27536,7 +27566,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -27555,7 +27585,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -27576,7 +27606,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -27589,7 +27619,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -27601,7 +27631,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -27609,27 +27639,27 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <direction placement="below">
         <direction-type>
@@ -27645,7 +27675,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -27663,7 +27693,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>420</duration>
+        <duration>1470</duration>
         <voice>5</voice>
         <type>eighth</type>
         <dot/>
@@ -27676,7 +27706,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -27692,7 +27722,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>5</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -27704,7 +27734,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -27719,7 +27749,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -27731,7 +27761,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>up</stem>
@@ -27744,12 +27774,12 @@
     <measure number="92" width="56.09">
       <note>
         <rest/>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>1</voice>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <direction placement="below">
         <direction-type>
@@ -27765,7 +27795,7 @@
           <step>A</step>
           <octave>1</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -27782,7 +27812,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -27797,7 +27827,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -27816,7 +27846,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -27834,7 +27864,7 @@
           <alter>-1</alter>
           <octave>6</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -27854,7 +27884,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <accidental>flat</accidental>
@@ -27865,7 +27895,7 @@
           </notations>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="43.20" default-y="25.00" print-object="no">
         <cue/>
@@ -27873,7 +27903,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -27896,7 +27926,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -27916,7 +27946,7 @@
           <step>B</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <accidental>natural</accidental>
@@ -27935,18 +27965,18 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -27957,7 +27987,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -27969,7 +27999,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -27982,7 +28012,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -28007,7 +28037,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>down</stem>
@@ -28022,7 +28052,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -28046,7 +28076,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28059,16 +28089,13 @@
         <beam number="2">continue</beam>
         <beam number="3">continue</beam>
         </note>
-      <forward>
-        <duration>1</duration>
-        </forward>
       <note default-x="188.32" default-y="-40.00">
         <cue/>
         <pitch>
           <step>E</step>
           <octave>4</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>natural</accidental>
@@ -28088,7 +28115,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28107,7 +28134,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28126,7 +28153,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28139,9 +28166,6 @@
         <beam number="2">continue</beam>
         <beam number="3">continue</beam>
         </note>
-      <forward>
-        <duration>1</duration>
-        </forward>
       <note default-x="267.53" default-y="-20.00">
         <cue/>
         <pitch>
@@ -28149,7 +28173,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28168,7 +28192,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28187,7 +28211,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28200,9 +28224,6 @@
         <beam number="2">continue</beam>
         <beam number="3">continue</beam>
         </note>
-      <forward>
-        <duration>1</duration>
-        </forward>
       <note default-x="328.71" default-y="-5.00">
         <cue/>
         <pitch>
@@ -28210,7 +28231,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <accidental>flat</accidental>
@@ -28230,7 +28251,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28249,7 +28270,7 @@
           <step>G</step>
           <octave>5</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28268,7 +28289,7 @@
           <step>A</step>
           <octave>5</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28281,9 +28302,6 @@
         <beam number="2">continue</beam>
         <beam number="3">continue</beam>
         </note>
-      <forward>
-        <duration>1</duration>
-        </forward>
       <note default-x="407.92" default-y="15.00">
         <cue/>
         <pitch>
@@ -28291,7 +28309,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>34</duration>
+        <duration>120</duration>
         <voice>1</voice>
         <type>32nd</type>
         <time-modification>
@@ -28308,25 +28326,15 @@
           <slur type="stop" number="1"/>
           </notations>
         </note>
-      <note print-object="no">
-        <rest/>
-        <duration>30</duration>
-        <voice>1</voice>
-        <type>64th</type>
-        <staff>1</staff>
-        </note>
       <backup>
-        <duration>1470</duration>
+        <duration>5145</duration>
         </backup>
-      <forward>
-        <duration>4</duration>
-        </forward>
       <note default-x="106.14" default-y="-138.10">
         <pitch>
           <step>A</step>
           <octave>3</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -28339,7 +28347,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -28353,18 +28361,11 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
         <stem>down</stem>
-        <staff>2</staff>
-        </note>
-      <note print-object="no">
-        <rest/>
-        <duration>26</duration>
-        <voice>5</voice>
-        <type>128th</type>
         <staff>2</staff>
         </note>
       </measure>
@@ -28374,7 +28375,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28389,7 +28390,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -28408,7 +28409,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -28426,7 +28427,7 @@
           <alter>-1</alter>
           <octave>6</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -28445,7 +28446,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -28461,7 +28462,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -28474,14 +28475,14 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1260</duration>
+        <duration>4410</duration>
         </backup>
       <note default-x="47.10" default-y="25.00" print-object="no">
         <cue/>
@@ -28489,7 +28490,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -28512,7 +28513,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <time-modification>
@@ -28532,7 +28533,7 @@
           <step>B</step>
           <octave>5</octave>
           </pitch>
-        <duration>20</duration>
+        <duration>70</duration>
         <voice>2</voice>
         <type>64th</type>
         <accidental>natural</accidental>
@@ -28551,28 +28552,28 @@
           </notations>
         </note>
       <forward>
-        <duration>720</duration>
+        <duration>2520</duration>
         </forward>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1200</duration>
+        <duration>4200</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -28583,7 +28584,7 @@
           <alter>1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <accidental>sharp</accidental>
@@ -28600,7 +28601,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -28613,7 +28614,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -28627,7 +28628,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28643,7 +28644,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28651,7 +28652,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -28669,28 +28670,28 @@
           <step>G</step>
           <octave>5</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>960</duration>
+        <duration>3360</duration>
         </backup>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -28708,7 +28709,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28727,7 +28728,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28740,7 +28741,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -28749,20 +28750,20 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-143.10">
         <pitch>
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28779,7 +28780,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28791,7 +28792,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28799,14 +28800,14 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -28824,7 +28825,7 @@
           <step>E</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -28844,7 +28845,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28857,7 +28858,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -28866,7 +28867,7 @@
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
@@ -28887,7 +28888,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>960</duration>
+        <duration>3360</duration>
         <voice>1</voice>
         <type>half</type>
         <stem>up</stem>
@@ -28895,20 +28896,20 @@
         </note>
       <note print-object="no">
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest>
           <display-step>D</display-step>
           <display-octave>5</display-octave>
           </rest>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>2</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -28918,7 +28919,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28937,7 +28938,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -28949,7 +28950,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -28958,7 +28959,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -28968,7 +28969,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -28987,7 +28988,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -29000,7 +29001,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29008,17 +29009,17 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -29037,7 +29038,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -29056,7 +29057,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -29068,7 +29069,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -29077,7 +29078,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -29087,7 +29088,7 @@
           <step>F</step>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29105,7 +29106,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29113,7 +29114,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -29123,7 +29124,7 @@
           <step>F</step>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29141,7 +29142,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29167,7 +29168,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29185,7 +29186,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29198,7 +29199,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29209,7 +29210,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29225,7 +29226,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29236,7 +29237,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29249,7 +29250,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29261,7 +29262,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -29276,7 +29277,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -29289,7 +29290,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29303,7 +29304,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29315,7 +29316,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -29333,7 +29334,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -29341,7 +29342,7 @@
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="94.27" default-y="-170.00">
         <pitch>
@@ -29349,7 +29350,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -29363,7 +29364,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -29377,7 +29378,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29393,7 +29394,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29405,7 +29406,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29419,7 +29420,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29431,7 +29432,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29445,7 +29446,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29456,7 +29457,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29469,7 +29470,7 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29480,7 +29481,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29493,7 +29494,7 @@
           <step>C</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29504,7 +29505,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -29518,7 +29519,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -29530,7 +29531,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -29548,14 +29549,14 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-170.00">
         <pitch>
@@ -29563,7 +29564,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -29577,7 +29578,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -29591,7 +29592,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29599,7 +29600,7 @@
         </note>
       <note print-object="no">
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <staff>1</staff>
@@ -29609,7 +29610,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -29620,7 +29621,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -29633,14 +29634,14 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.72" default-y="-125.00">
         <pitch>
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29651,7 +29652,7 @@
           <step>F</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -29666,7 +29667,7 @@
           <step>D</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -29679,7 +29680,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -29693,7 +29694,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -29706,7 +29707,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <accidental>flat</accidental>
@@ -29718,7 +29719,7 @@
           </notations>
         </note>
       <backup>
-        <duration>240</duration>
+        <duration>840</duration>
         </backup>
       <note default-x="240.15" default-y="-5.00" print-object="no">
         <cue/>
@@ -29727,7 +29728,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -29743,7 +29744,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -29760,7 +29761,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -29776,7 +29777,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -29793,7 +29794,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -29809,7 +29810,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -29826,7 +29827,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -29842,7 +29843,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>3</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -29853,7 +29854,7 @@
         <beam number="4">end</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="10.36" default-y="-135.00">
         <pitch>
@@ -29861,7 +29862,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -29893,7 +29894,7 @@
           <step>F</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -29906,7 +29907,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -29918,7 +29919,7 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -29929,7 +29930,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -29943,7 +29944,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <accidental>natural</accidental>
@@ -29956,11 +29957,11 @@
           </notations>
         </note>
       <backup>
-        <duration>480</duration>
+        <duration>1680</duration>
         </backup>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>2</voice>
         <type>eighth</type>
         <staff>1</staff>
@@ -29972,7 +29973,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>2</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -29988,7 +29989,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>2</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -30005,7 +30006,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>2</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -30021,7 +30022,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>2</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -30038,7 +30039,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>2</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -30054,7 +30055,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>2</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -30071,7 +30072,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>2</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -30093,7 +30094,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>30</duration>
+        <duration>105</duration>
         <voice>2</voice>
         <type>64th</type>
         <stem>none</stem>
@@ -30104,7 +30105,7 @@
         <beam number="4">end</beam>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="90.47" default-y="-197.13">
         <pitch>
@@ -30112,7 +30113,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>1440</duration>
+        <duration>5040</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
@@ -30120,14 +30121,14 @@
         <staff>2</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="90.84" default-y="-172.13">
         <pitch>
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>7</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30143,7 +30144,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>7</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30156,7 +30157,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>7</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30168,7 +30169,7 @@
           <step>G</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>7</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30180,7 +30181,7 @@
           <step>C</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>7</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30192,7 +30193,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>7</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -30206,7 +30207,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>7</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -30237,7 +30238,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -30252,7 +30253,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <staff>1</staff>
@@ -30262,7 +30263,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -30277,7 +30278,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30292,7 +30293,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <staff>1</staff>
@@ -30302,7 +30303,7 @@
           <step>A</step>
           <octave>4</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>down</stem>
@@ -30317,7 +30318,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>down</stem>
@@ -30329,7 +30330,7 @@
           <alter>-1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -30348,7 +30349,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -30356,7 +30357,7 @@
         </note>
       <note>
         <rest/>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <staff>1</staff>
@@ -30366,7 +30367,7 @@
           <step>C</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>down</stem>
@@ -30381,21 +30382,21 @@
           <step>A</step>
           <octave>5</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>1</voice>
         <type>16th</type>
         <stem>down</stem>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="90.47" default-y="-125.00">
         <pitch>
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30410,7 +30411,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -30424,7 +30425,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -30440,7 +30441,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30455,7 +30456,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -30469,7 +30470,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -30485,7 +30486,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30500,7 +30501,7 @@
           <step>F</step>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -30514,7 +30515,7 @@
           <alter>-1</alter>
           <octave>3</octave>
           </pitch>
-        <duration>120</duration>
+        <duration>420</duration>
         <voice>5</voice>
         <type>16th</type>
         <stem>up</stem>
@@ -30526,7 +30527,7 @@
           </notations>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="90.47" default-y="-135.00">
         <pitch>
@@ -30534,7 +30535,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -30546,7 +30547,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -30558,7 +30559,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>6</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -30579,7 +30580,7 @@
           <step>D</step>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -30597,7 +30598,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -30608,7 +30609,7 @@
           <step>D</step>
           <octave>6</octave>
           </pitch>
-        <duration>180</duration>
+        <duration>630</duration>
         <voice>1</voice>
         <type>16th</type>
         <dot/>
@@ -30622,7 +30623,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>60</duration>
+        <duration>210</duration>
         <voice>1</voice>
         <type>32nd</type>
         <stem>down</stem>
@@ -30648,7 +30649,7 @@
           <step>C</step>
           <octave>6</octave>
           </pitch>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>1</voice>
         <type>quarter</type>
         <stem>down</stem>
@@ -30663,7 +30664,7 @@
           <alter>-1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <stem>down</stem>
@@ -30674,13 +30675,13 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>1</voice>
         <type>eighth</type>
         <staff>1</staff>
         </note>
       <backup>
-        <duration>1440</duration>
+        <duration>5040</duration>
         </backup>
       <note default-x="13.80" default-y="-135.00">
         <pitch>
@@ -30688,7 +30689,7 @@
           <alter>-1</alter>
           <octave>2</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30700,7 +30701,7 @@
           <step>D</step>
           <octave>3</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>
@@ -30708,21 +30709,21 @@
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>480</duration>
+        <duration>1680</duration>
         <voice>5</voice>
         <type>quarter</type>
         <staff>2</staff>
         </note>
       <note>
         <rest/>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <staff>2</staff>
@@ -30742,7 +30743,7 @@
           <alter>-1</alter>
           <octave>1</octave>
           </pitch>
-        <duration>240</duration>
+        <duration>840</duration>
         <voice>5</voice>
         <type>eighth</type>
         <stem>up</stem>


### PR DESCRIPTION
In the score Beethoven/Piano_Sonatas/17-2, we can see some unwanted/incorrect invisible rests in the bar 94:
![broken bar 94](https://github.com/user-attachments/assets/5f1c8fd4-6787-4f28-8c51-9850cbedc0b7)

I was facing some issues because the `<division>` of this musicxml was 480, which is unsuited to represent this 14:8 implicit tuplet, resulting in inaccuracies in `<duration>` tags, and therefore some weird `<forward>`/`<backup>` tags. Instead of 480, I set it to 1680, which should accurately represent triplets, this 14:8 tuplet, and the 10:8 tuplet in bar 5.

Speaking of bar 5, there are also some unwanted rests (and missing tuplet info in the XML as those 32nd notes should not fit in there):
![broken bar 5](https://github.com/user-attachments/assets/11cf830d-31a5-4da5-80f8-390828b0bfe1)

According to this [reference](https://vmirror.imslp.org/files/imglnks/usimg/f/f4/IMSLP895432-PMLP1462-Sonata_No._17.pdf), the half notes in both bars 5 and 94 should be dotted, and the remaining notes should therefore be in another voice:
![ref bar 94](https://github.com/user-attachments/assets/bfd80115-ba79-4cb2-810a-ec3d0e1d74a1)
![ref bar 5](https://github.com/user-attachments/assets/6f4c662b-1d31-4776-83b5-b1b1d2c45e85)

In this PR, I fixed the `<division>` tag, as well as all `<duration>` of the piece to reflect the change. I also added the (implicit) tuplet info in measure 5, added the missing dot to the half notes in the two problematic measures, and moved the cue notes to voice 2 to not overlap voice 1 (adding an invisible half rest at the beginning of the voice to pad):
![fixed bar 94](https://github.com/user-attachments/assets/0808c11d-1bba-4ccb-bf0f-a83b68d7867c)
![fixed bar 5](https://github.com/user-attachments/assets/0c7ad3e1-f142-45e3-b66c-b3916a959aa9)
