### PR TITLE
Remove incorrect rest in Beethoven/Piano_Sonatas/17-2

### DIFF
--- a/Beethoven/Piano_Sonatas/17-2/xml_score.musicxml
+++ b/Beethoven/Piano_Sonatas/17-2/xml_score.musicxml
@@ -28697,16 +28697,6 @@
         <type>quarter</type>
         <staff>1</staff>
         </note>
-      <backup>
-        <duration>840</duration>
-        </backup>
-      <note>
-        <rest/>
-        <duration>840</duration>
-        <voice>2</voice>
-        <type>eighth</type>
-        <staff>1</staff>
-        </note>
       <direction placement="below">
         <direction-type>
           <dynamics default-x="3.29" default-y="-76.30" relative-y="-40.00">


### PR DESCRIPTION
In Beethoven/Piano_Sonatas/17-2, there is a rest in staff 1 that should not be there:
![broken score](https://github.com/user-attachments/assets/c39f6510-3c39-4e57-b878-0b36d13c196b)

This PR simply removes it (as well as the associated `<backup>` tag that was used to compensate the shift introduced by this additional rest).
![fixed score](https://github.com/user-attachments/assets/f37a4735-7f90-4993-a641-b08ffb003a33)

Note that this score contains other errors. I might try to fix them at some point, but probably in another PR. They are quite more complex than this one, and are frequent across the whole dataset. It's about the `<divisions>` tag not allowing to represent exactly all divisions of the score (like unusual tuplets), resulting in rounding errors in durations, and therefore spurious `<forward>` tags, as well as invisible rests to compensate for the shift introduced by the rounding.

**EDIT: As I was studying a lot of scores in parallel, I've just figured out that I've already opened a PR for this score (#16). This PR is about a different issue, and is *not* compatible with the other one as durations won't match. I can update this one when/if you merge the other one. Or I can directly integrate this change in the other PR if you prefer. I'll pass this PR as draft in the meantime.**