### PR TITLE
Fix an invisible note that should be visible in Bach Prelude BWV 876

### DIFF
--- a/Bach/Prelude/bwv_876/xml_score.musicxml
+++ b/Bach/Prelude/bwv_876/xml_score.musicxml
@@ -11227,7 +11227,7 @@
         <staff>1</staff>
         <beam number="1">end</beam>
         </note>
-      <note default-x="64.39" default-y="-25.00" print-object="no">
+      <note default-x="64.39" default-y="-25.00">
         <pitch>
           <step>A</step>
           <alter>-1</alter>


### PR DESCRIPTION
In measure 51 of Bach Prelude BWV 876, there is a note which is invisible for no reason that I can see (only the stem is invisible on the image because of the notehead of another voice drawn on top of the notehead in voice 1, but it is indeed invisible below).
![invisible note](https://github.com/user-attachments/assets/da14d3df-5ded-425e-a734-eefefe1a01fa)

In the references I checked, the stem is always visible:
![references](https://github.com/user-attachments/assets/6fccd265-f717-4382-a2ab-790ef1193e75)

This PR simply remove the invisible tag