### PR TITLE
Fix typo in Bach/Fugue/bwv_846 + voice attribution 

### DIFF
--- a/Bach/Fugue/bwv_846/xml_score.musicxml
+++ b/Bach/Fugue/bwv_846/xml_score.musicxml
@@ -6118,11 +6118,13 @@
       <note default-x="131.27" default-y="-30.00">
         <pitch>
           <step>G</step>
+          <alter>1</alter>
           <octave>4</octave>
           </pitch>
         <duration>8</duration>
         <voice>1</voice>
         <type>eighth</type>
+        <accidental>sharp</accidental>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">begin</beam>
@@ -6293,6 +6295,7 @@
         <duration>8</duration>
         <voice>3</voice>
         <type>eighth</type>
+        <accidental>natural</accidental>
         <stem>up</stem>
         <staff>1</staff>
         <beam number="1">continue</beam>

--- a/Bach/Fugue/bwv_846/xml_score.musicxml
+++ b/Bach/Fugue/bwv_846/xml_score.musicxml
@@ -6115,22 +6115,7 @@
         <beam number="2">end</beam>
         <beam number="3">end</beam>
         </note>
-      <note default-x="131.27" default-y="-30.00">
-        <pitch>
-          <step>G</step>
-          <alter>1</alter>
-          <octave>4</octave>
-          </pitch>
-        <duration>8</duration>
-        <voice>1</voice>
-        <type>eighth</type>
-        <accidental>sharp</accidental>
-        <stem>up</stem>
-        <staff>1</staff>
-        <beam number="1">begin</beam>
-        </note>
       <note default-x="131.27" default-y="-20.00">
-        <chord/>
         <pitch>
           <step>B</step>
           <octave>4</octave>
@@ -6140,25 +6125,9 @@
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
-        </note>
-      <note default-x="166.57" default-y="-25.00">
-        <pitch>
-          <step>A</step>
-          <octave>4</octave>
-          </pitch>
-        <duration>8</duration>
-        <tie type="start"/>
-        <voice>1</voice>
-        <type>eighth</type>
-        <stem>up</stem>
-        <staff>1</staff>
-        <beam number="1">end</beam>
-        <notations>
-          <tied type="start"/>
-          </notations>
+        <beam number="1">begin</beam>
         </note>
       <note default-x="166.57" default-y="-15.00">
-        <chord/>
         <pitch>
           <step>C</step>
           <octave>5</octave>
@@ -6168,6 +6137,7 @@
         <type>eighth</type>
         <stem>up</stem>
         <staff>1</staff>
+        <beam number="1">end</beam>
         </note>
       <note default-x="201.86" default-y="-10.00">
         <pitch>
@@ -6268,9 +6238,36 @@
         <staff>1</staff>
         <beam number="1">end</beam>
         </note>
-      <forward>
-        <duration>16</duration>
-        </forward>
+      <note default-x="131.27" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <alter>1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>8</duration>
+        <voice>3</voice>
+        <type>eighth</type>
+        <accidental>sharp</accidental>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        </note>
+      <note default-x="166.57" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>8</duration>
+        <tie type="start"/>
+        <voice>3</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">end</beam>
+        <notations>
+          <tied type="start"/>
+          </notations>
+        </note>
       <note default-x="201.86" default-y="-25.00">
         <pitch>
           <step>A</step>


### PR DESCRIPTION
Fixes #18.

Add a missing sharp on the G on beat 2, and move it (along with the second of the beam) from voice 1 to voice 3 because it makes more sense:
- The voice 3 does not have a gap anymore
- The tie does not change voice
- The two references I came across agree on this voice attribution

Original voicing:
![Original voicing](https://github.com/user-attachments/assets/559662bd-e2f6-40b1-b29d-5aaa00fc1257)

New voicing (with the fixed G#, and therefore the natural one a couple of notes after):
![New voicing](https://github.com/user-attachments/assets/2bed8afe-390f-46a5-a1b4-816d096b9df3)

References:
![ref1](https://github.com/user-attachments/assets/75be5044-69ef-4023-8ad6-e09b1322b7af)
![ref2](https://github.com/user-attachments/assets/df4de6fd-610b-40cf-9a54-2b0ab163c7d3)
