### PR TITLE
Fix a problematic tuplet in Bach/Prelude/bwv_874

### DIFF
--- a/Bach/Prelude/bwv_874/xml_score.musicxml
+++ b/Bach/Prelude/bwv_874/xml_score.musicxml
@@ -8572,13 +8572,12 @@
           <step>G</step>
           <octave>4</octave>
           </pitch>
-        <duration>9</duration>
+        <duration>6</duration>
         <voice>2</voice>
         <type>eighth</type>
         <time-modification>
-          <actual-notes>8</actual-notes>
-          <normal-notes>18</normal-notes>
-          <normal-type>16th</normal-type>
+          <actual-notes>4</actual-notes>
+          <normal-notes>6</normal-notes>
           </time-modification>
         <stem>down</stem>
         <staff>1</staff>
@@ -8591,32 +8590,29 @@
           <display-step>C</display-step>
           <display-octave>4</display-octave>
           </rest>
-        <duration>9</duration>
+        <duration>6</duration>
         <voice>2</voice>
         <type>eighth</type>
         <time-modification>
-          <actual-notes>8</actual-notes>
-          <normal-notes>18</normal-notes>
-          <normal-type>16th</normal-type>
+          <actual-notes>4</actual-notes>
+          <normal-notes>6</normal-notes>
+          </time-modification>
+        <staff>1</staff>
+        </note>
+      <note>
+        <rest/>
+        <duration>12</duration>
+        <voice>2</voice>
+        <type>quarter</type>
+        <time-modification>
+          <actual-notes>4</actual-notes>
+          <normal-notes>6</normal-notes>
+          <normal-type>eighth</normal-type>
           </time-modification>
         <staff>1</staff>
         <notations>
           <tuplet type="stop"/>
           </notations>
-        </note>
-      <note>
-        <rest/>
-        <duration>2</duration>
-        <voice>2</voice>
-        <type>16th</type>
-        <staff>1</staff>
-        </note>
-      <note>
-        <rest/>
-        <duration>4</duration>
-        <voice>2</voice>
-        <type>eighth</type>
-        <staff>1</staff>
         </note>
       <backup>
         <duration>48</duration>


### PR DESCRIPTION
The score Bach/Prelude/bwv_874 is very special, as it uses voices that switch between simple and compound meters for the complete score. Therefore, you have sometimes a quarter note in parallel to 3 eighth notes, with sometimes a voice that change from simple to compound within a measure. Here is an example:

![Example of parallel simple/compound measure](https://github.com/user-attachments/assets/6f52f02c-8fd2-4191-8893-25a6f495ab8a)


As MusicXML does not support this kind of sorcery, the score is written using a compound meter, and a bunch of hidden tuplets 2:3, 4:6 or 8:12 are present everywhere to correctly align the timings (some of them are not hidden though, I'm not sure why).

However, in measure 21, there is a strange 8:18 tuplet, which does not respect the correct ratio of 2:3 that we would expect from this hack (in the following images, the hidden tuplets have been explicitly made visible to that the problem is clearly visible):

![image](https://github.com/user-attachments/assets/3f50e44b-69bb-476f-989e-cf3f6e0ba4a1)

It results in the voice 2 being ending with some strangely positioned rests, especially the one in the tuplet, which does not really align with anything else.

In the references of this score I found (see below), this rest is always aligned with the second note of the sixteenth notes beam in voice 1 (and therefore located at half of the beat as here we have voice 1 compound and voice 2 simple). This is not the case in the MusicXML in ASAP, where the rest falls between the last and the one-but-last note of the beam.
![ref1](https://github.com/user-attachments/assets/5a2b4d9e-0d0a-474f-a495-d06b71de98ba)
![ref2](https://github.com/user-attachments/assets/7f09b65f-db1d-4225-942a-ee91a62d44a2)
![ref3](https://github.com/user-attachments/assets/c81272bc-ab85-40b5-9d46-3ab2bf935151)

Therefore, I changed the second half of the measure into a more "classical" 4:6 tuplet (I could have chosen to use two 2:3 triplets, I did that because there were another 4:6 in voice 1 just before, but I can change if you prefer), and replaced the two last 8th/16th rests by a simple quarter one as in the references. I also adapted the `<duration>` tags so that they match the new tuplet timings.

Here is the final version:
![fixed_color_tuplets](https://github.com/user-attachments/assets/accb9acb-0547-46f0-91c3-8cacc7b4e6bb)

Note that there should probably a lot more things to fix in this score, but I was only interested in those specific `<duration>` tags that were not making sense, so I only fixed this problematic tuplet.