### PR TITLE
Fix last bar of Chopin/Sonata_3/4th

### DIFF
--- a/Chopin/Sonata_3/4th/xml_score.musicxml
+++ b/Chopin/Sonata_3/4th/xml_score.musicxml
@@ -75998,20 +75998,13 @@
           <step>B</step>
           <octave>5</octave>
           </pitch>
-        <duration>617</duration>
+        <duration>720</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
-        <dot/>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>6</normal-notes>
-          <normal-type>eighth</normal-type>
-          </time-modification>
         <stem>down</stem>
         <staff>1</staff>
         <notations>
-          <tuplet type="start" bracket="no" show-number="none"/>
           <fermata type="upright"/>
           </notations>
         </note>
@@ -76021,46 +76014,19 @@
           <step>B</step>
           <octave>6</octave>
           </pitch>
-        <duration>617</duration>
+        <duration>720</duration>
         <voice>1</voice>
         <type>half</type>
         <dot/>
-        <dot/>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>6</normal-notes>
-          <normal-type>eighth</normal-type>
-          </time-modification>
         <stem>down</stem>
         <staff>1</staff>
         </note>
-      <backup>
-        <duration>2</duration>
-        </backup>
       <direction placement="below">
         <direction-type>
           <pedal type="stop" relative-x="10.47" relative-y="-180.83"/>
           </direction-type>
         <staff>1</staff>
         </direction>
-      <note print-object="no">
-        <rest/>
-        <duration>103</duration>
-        <voice>1</voice>
-        <type size="cue">eighth</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>6</normal-notes>
-          <normal-type>eighth</normal-type>
-          </time-modification>
-        <staff>1</staff>
-        <notations>
-          <tuplet type="stop"/>
-          </notations>
-        </note>
-      <forward>
-        <duration>2</duration>
-        </forward>
       <backup>
         <duration>720</duration>
         </backup>
@@ -76070,20 +76036,13 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>617</duration>
+        <duration>720</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
-        <dot/>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>6</normal-notes>
-          <normal-type>eighth</normal-type>
-          </time-modification>
         <stem>up</stem>
         <staff>2</staff>
         <notations>
-          <tuplet type="start" bracket="no" show-number="none"/>
           <fermata type="upright"/>
           </notations>
         </note>
@@ -76094,16 +76053,10 @@
           <alter>1</alter>
           <octave>4</octave>
           </pitch>
-        <duration>617</duration>
+        <duration>720</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
-        <dot/>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>6</normal-notes>
-          <normal-type>eighth</normal-type>
-          </time-modification>
         <stem>up</stem>
         <staff>2</staff>
         </note>
@@ -76113,16 +76066,10 @@
           <step>B</step>
           <octave>4</octave>
           </pitch>
-        <duration>617</duration>
+        <duration>720</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
-        <dot/>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>6</normal-notes>
-          <normal-type>eighth</normal-type>
-          </time-modification>
         <stem>up</stem>
         <staff>2</staff>
         </note>
@@ -76133,40 +76080,13 @@
           <alter>1</alter>
           <octave>5</octave>
           </pitch>
-        <duration>617</duration>
+        <duration>720</duration>
         <voice>5</voice>
         <type>half</type>
         <dot/>
-        <dot/>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>6</normal-notes>
-          <normal-type>eighth</normal-type>
-          </time-modification>
         <stem>up</stem>
         <staff>2</staff>
         </note>
-      <backup>
-        <duration>2</duration>
-        </backup>
-      <note print-object="no">
-        <rest/>
-        <duration>103</duration>
-        <voice>5</voice>
-        <type size="cue">eighth</type>
-        <time-modification>
-          <actual-notes>7</actual-notes>
-          <normal-notes>6</normal-notes>
-          <normal-type>eighth</normal-type>
-          </time-modification>
-        <staff>2</staff>
-        <notations>
-          <tuplet type="stop"/>
-          </notations>
-        </note>
-      <forward>
-        <duration>2</duration>
-        </forward>
       <barline location="right">
         <bar-style>light-heavy</bar-style>
         </barline>


### PR DESCRIPTION
The last bar of Chopin/Sonata_3/4th was quite messed up, with unaligned notes, invisible rests, and double dotted half notes not coherent with the time signature. There was also some `<time-modification>` tags in there, I don't really know why.
![Last bar before modifications](https://github.com/user-attachments/assets/c437c670-9a33-4f5f-80fe-6b53fcf96555)

Therefore, I removed the invisible rests, the time modification tags, and fixed the durations:
![Last bar after modifications](https://github.com/user-attachments/assets/58ca6932-93d2-4654-9c90-16865eaa8cbe)

Here is some [reference](https://s9.imslp.org/files/imglnks/usimg/9/9b/IMSLP114619-PMLP02364-FChopin_Piano_Sonata_No.3,_Op.58_BH8.pdf) [scores](https://ks15.imslp.org/files/imglnks/usimg/6/6e/IMSLP638961-PMLP2364-ChopinSonataBMinor-KohlerEdition.pdf) from IMSLP:
![image](https://github.com/user-attachments/assets/ccfb0c51-1094-4bda-a10c-b4b9c811667d)
![image](https://github.com/user-attachments/assets/b7c6465f-4e33-437b-8224-aa6bbf846fe1)

