### PR TITLE
Fix malformed metronome in Ravel Alborada MusicXML

### DIFF
--- a/Ravel/Miroirs/4_Alborada_del_gracioso/xml_score.musicxml
+++ b/Ravel/Miroirs/4_Alborada_del_gracioso/xml_score.musicxml
@@ -26291,10 +26291,10 @@
       </note>
       <direction placement="above">
         <direction-type>
-          <metronome default-y="35" font-family="EngraverTextT" font-size="10.3">
-            <beat-unit>eighth</beat-unit>
-            <beat-unit>eighth</beat-unit>
-          </metronome>
+          <!-- <metronome default-y="35" font-family="EngraverTextT" font-size="10.3"> -->
+          <!--   <beat-unit>eighth</beat-unit> -->
+          <!--   <beat-unit>eighth</beat-unit> -->
+          <!-- </metronome> -->
         </direction-type>
         <staff>1</staff>
       </direction>

--- a/Ravel/Miroirs/4_Alborada_del_gracioso/xml_score.musicxml
+++ b/Ravel/Miroirs/4_Alborada_del_gracioso/xml_score.musicxml
@@ -26291,10 +26291,11 @@
       </note>
       <direction placement="above">
         <direction-type>
-          <!-- <metronome default-y="35" font-family="EngraverTextT" font-size="10.3"> -->
-          <!--   <beat-unit>eighth</beat-unit> -->
-          <!--   <beat-unit>eighth</beat-unit> -->
-          <!-- </metronome> -->
+          <metronome default-y="35" font-family="EngraverTextT" font-size="10.3">
+            <beat-unit>quarter</beat-unit>
+            <beat-unit-dot/>
+            <per-minute>92</per-minute>
+          </metronome>
         </direction-type>
         <staff>1</staff>
       </direction>


### PR DESCRIPTION
Remove a metronome marking without per-minute from xml_score.musicxml.